### PR TITLE
(fix): ci job that creates github releases

### DIFF
--- a/deploy/release.groovy
+++ b/deploy/release.groovy
@@ -56,6 +56,25 @@ def cd (b){
         sh 'npm run build'
     }
 
+    stage('unit test'){
+        sh 'npm run test:unit'
+    }
+
+    stage('func test'){
+        dir('runtime'){
+            container('ui'){
+                sh '''
+        /usr/bin/Xvfb :99 -screen 0 1024x768x24 &
+        export API_URL=https://api.prod-preview.openshift.io/api/
+        export NODE_ENV=inmemory
+        npm install
+        ./tests/run_functional_tests.sh smokeTest
+    '''
+            }
+        }
+        sh './scripts/run-functests.sh'
+    }
+
     stage('release'){
         def published = npmRelease{
             branch = b

--- a/deploy/release.groovy
+++ b/deploy/release.groovy
@@ -56,14 +56,6 @@ def cd (b){
         sh 'npm run build'
     }
 
-    stage('unit test'){
-        sh 'npm run test:unit'
-    }
-
-    stage('func test'){
-        sh './scripts/run-functests.sh'
-    }
-
     stage('release'){
         def published = npmRelease{
             branch = b


### PR DESCRIPTION
@michaelkleinhenz and @nimishamukherjee found that github releases were out-of-date. The ci build master job was failing due to the functional stage.

I also realized that functional tests and unit tests are validated twice in this CI jobs, as shown in the following picture:
![screen shot 2017-07-05 at 2 38 00 pm](https://user-images.githubusercontent.com/3602792/27864615-93752a66-618f-11e7-925d-9f5a5500b0e0.png)
