### PR TITLE
Introducing patternfly-ng

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,11 +93,12 @@
     "ng2-dragula": "1.3.0",
     "ng2-truncate": "1.3.5",
     "ngx-base": "1.2.9",
-    "ngx-dropdown": "0.0.22",
+    "ngx-bootstrap": "1.7.1",
     "ngx-fabric8-wit": "6.18.11",
     "ngx-login-client": "0.6.32",
     "ngx-modal": "0.0.29",
     "ngx-widgets": "0.15.2",
+    "patternfly-ng": "0.0.13",
     "reflect-metadata": "0.1.10",
     "rxjs": "5.2.0",
     "zone.js": "0.8.5"

--- a/runtime/src/app/app.module.ts
+++ b/runtime/src/app/app.module.ts
@@ -7,8 +7,9 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 // FIXME: do we really need to have this modules on top-level?
-import { DropdownModule } from 'ng2-bootstrap';
-import { TabsModule, TooltipModule } from 'ng2-bootstrap';
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
+import { TabsModule } from 'ng2-bootstrap';
 import { TruncateModule } from 'ng2-truncate';
 
 import { Broadcaster, Logger, Notifications } from 'ngx-base';
@@ -49,6 +50,7 @@ let providers: any[] = [
 // The inmemory environment variable is checked and if present then the in-memory dataset is added.
 if (process.env.ENV == 'inmemory') {
   serviceImports = [
+    BsDropdownConfig,
     Logger,
     AuthenticationService,
     Broadcaster,
@@ -60,9 +62,12 @@ if (process.env.ENV == 'inmemory') {
     {
       provide: Spaces,
       useExisting: SpacesService
-    }
+    },
+    TooltipConfig
   ];
   providers = [
+    BsDropdownConfig,
+
     GlobalSettings,
     witApiUrlProvider,
     realmProvider,
@@ -77,7 +82,8 @@ if (process.env.ENV == 'inmemory') {
     {
       provide: Http,
       useExisting: HttpServiceLGC
-    }
+    },
+    TooltipConfig
   ];
 } else {
   serviceImports = [
@@ -113,12 +119,12 @@ if (process.env.ENV == 'inmemory') {
     AppRoutingModule,
     BrowserAnimationsModule,
     BrowserModule,
-    DropdownModule,
+    BsDropdownModule.forRoot(),
     FormsModule,
     HttpModule,
     ModalModule,
     TabsModule,
-    TooltipModule,
+    TooltipModule.forRoot(),
     TruncateModule
   ],
   declarations: [

--- a/src/app/components/card/card.component.html
+++ b/src/app/components/card/card.component.html
@@ -5,11 +5,11 @@
       <span class="wi-type-icon fa {{cardValue.type}}"></span>
       <span> {{cardValue?.id}} </span>
     </div>
-    <span class="dropdown-kebab-pf" dropdown>
-      <button class="btn btn-link color-grey" type="button" aria-haspopup="true" aria-expanded="true" (click)="kebabClick($event)" dropdownToggle>
+    <span class="dropdown-kebab-pf dropdown" dropdown>
+      <button class="btn btn-link color-grey dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="true" (click)="kebabClick($event)" dropdownToggle>
         <span class="fa fa-ellipsis-v"></span>
       </button>
-      <ul class="dropdown-menu-right" aria-labelledby="dropdownKebabRight" dropdownMenu>
+      <ul class="dropdown-menu-right dropdown-menu" aria-labelledby="dropdownKebabRight" *dropdownMenu>
         <li *ngFor="let menu of cardValue.menuItem" [attr.id]="menu.id">
             <a *ngIf="menu.link" [routerLink]="menu.link?[menu.link]:null" [queryParams]="menu.link?existingQueryParams:null" (click)="kebabMenuClick($event, menu.id)">
               {{menu.value}}

--- a/src/app/components/iterations-panel/iterations-panel.component.html
+++ b/src/app/components/iterations-panel/iterations-panel.component.html
@@ -15,15 +15,15 @@
                 [routerLink]="[]" [attr.data-id]="iteration.id"
                 [queryParams]="{iteration: iteration.attributes.resolved_parent_path + '/' + iteration.attributes.name}" [dragula]="'wi-bag'">
           <div class="iteration-subheader">
-            <div *ngIf="loggedIn" class="dropdown-kebab-pf pull-right" dropdown>
-              <button class="btn btn-link"
+            <div *ngIf="loggedIn" class="dropdown-kebab-pf pull-right dropdown" dropdown>
+              <button class="btn btn-link dropdown-toggle"
                       type="button"
                       aria-haspopup="true"
                       aria-expanded="true"
                       dropdownToggle>
                 <i class="fa fa-ellipsis-v"></i>
               </button>
-              <ul class="dropdown-menu-right" dropdownMenu>
+              <ul class="dropdown-menu-right dropdown-menu" *dropdownMenu>
                 <li>
                   <a class="pointer" (click)="modal.openCreateUpdateModal('update', iteration, $event);">
                     Edit
@@ -107,15 +107,15 @@
                 [queryParams]="{iteration: iteration.attributes.resolved_parent_path + '/' + iteration.attributes.name}" [dragula]="'wi-bag'">
             <div class="pull-right">
               <span class="badge">{{iteration.relationships?.workitems?.meta?.total}}</span>
-              <div *ngIf="loggedIn" class="dropdown-kebab-pf dib" dropdown>
-                <button class="btn btn-link"
+              <div *ngIf="loggedIn" class="dropdown-kebab-pf dib dropdown" dropdown>
+                <button class="btn btn-link dropdown-toggle"
                         type="button"
                         aria-haspopup="true"
                         aria-expanded="true"
                         dropdownToggle>
                   <i class="fa fa-ellipsis-v"></i>
                 </button>
-                <ul class="dropdown-menu-right" dropdownMenu>
+                <ul class="dropdown-menu-right dropdown-menu" *dropdownMenu>
                   <li>
                     <a class="pointer" (click)="modal.openCreateUpdateModal('update', iteration, $event);">
                       Edit
@@ -166,15 +166,15 @@
             [routerLink]="[]" [queryParams]="{iteration: iteration.attributes.resolved_parent_path + '/' + iteration.attributes.name}" [dragula]="'wi-bag'" [attr.data-id]="iteration.id">
           <div class="pull-right">
             <span class="badge">{{iteration.relationships?.workitems?.meta?.total}}</span>
-            <div *ngIf="loggedIn" class="dropdown-kebab-pf dib" dropdown>
-              <button class="btn btn-link"
+            <div *ngIf="loggedIn" class="dropdown-kebab-pf dib dropdown" dropdown>
+              <button class="btn btn-link dropdown-toggle"
                       type="button"
                       aria-haspopup="true"
                       aria-expanded="true"
                       dropdownToggle>
                 <i class="fa fa-ellipsis-v"></i>
               </button>
-              <ul class="dropdown-menu-right" dropdownMenu>
+              <ul class="dropdown-menu-right" *dropdownMenu>
                 <li>
                   <a class="pointer" (click)="modal.openCreateUpdateModal('update', iteration, $event);">
                     Edit

--- a/src/app/components/iterations-panel/iterations-panel.module.ts
+++ b/src/app/components/iterations-panel/iterations-panel.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
 
 import { CollapseModule } from 'ng2-bootstrap';
-import { DropdownModule } from 'ng2-bootstrap';
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
 import {
   WidgetsModule
@@ -16,19 +16,19 @@ import { MyDatePickerModule } from 'mydatepicker';
 import { IterationComponent } from './iterations-panel.component';
 import { IterationService } from '../../services/iteration.service';
 import { ModalModule } from 'ngx-modal';
-import { TooltipModule } from 'ng2-bootstrap';
+import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 import { TruncateModule } from 'ng2-truncate';
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CollapseModule,
     CommonModule,
     DragulaModule,
-    DropdownModule,
     FormsModule,
     MyDatePickerModule,
     ModalModule,
-    TooltipModule,
+    TooltipModule.forRoot(),
     TruncateModule,
     WidgetsModule,
     RouterModule
@@ -38,6 +38,6 @@ import { TruncateModule } from 'ng2-truncate';
     IterationComponent
   ],
   exports: [IterationComponent],
-  providers: [IterationService]
+  providers: [BsDropdownConfig, IterationService, TooltipConfig]
 })
 export class IterationModule { }

--- a/src/app/components/planner-board/planner-board.module.ts
+++ b/src/app/components/planner-board/planner-board.module.ts
@@ -10,10 +10,10 @@ import {
 
 import { ModalModule } from 'ngx-modal';
 import { DragulaModule } from 'ng2-dragula';
-import { DropdownModule } from 'ng2-bootstrap';
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { EventService } from './../../services/event.service';
 import { TreeModule } from 'angular2-tree-component';
-import { TooltipModule } from 'ng2-bootstrap';
+import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 import { TruncateModule } from 'ng2-truncate';
 import { Broadcaster, Logger } from 'ngx-base';
 import {
@@ -49,6 +49,7 @@ let providers = [];
 
 if (process.env.ENV == 'inmemory') {
   providers = [
+    BsDropdownConfig,
     EventService,
     GlobalSettings,
     WorkItemService,
@@ -58,10 +59,12 @@ if (process.env.ENV == 'inmemory') {
     {
       provide: HttpService,
       useClass: MockHttp
-    }
+    },
+    TooltipConfig
   ];
 } else {
   providers = [
+    BsDropdownConfig,
     EventService,
     GlobalSettings,
     WorkItemService,
@@ -74,7 +77,8 @@ if (process.env.ENV == 'inmemory') {
         return new HttpService(backend, options, auth);
       },
       deps: [XHRBackend, RequestOptions, AuthenticationService]
-    }
+    },
+    TooltipConfig
   ];
 }
 
@@ -82,10 +86,10 @@ if (process.env.ENV == 'inmemory') {
 @NgModule({
   imports: [
     AlmIconModule,
+    BsDropdownModule.forRoot(),
     CommonModule,
     DialogModule,
     DragulaModule,
-    DropdownModule,
     FabPlannerAssociateIterationModalModule,
     HttpModule,
     InfiniteScrollModule,
@@ -94,7 +98,7 @@ if (process.env.ENV == 'inmemory') {
     PlannerBoardRoutingModule,
     SidepanelModule,
     ToolbarPanelModule,
-    TooltipModule,
+    TooltipModule.forRoot(),
     TreeModule,
     TreeListModule,
     TruncateModule,

--- a/src/app/components/planner-list/planner-list.module.ts
+++ b/src/app/components/planner-list/planner-list.module.ts
@@ -10,7 +10,8 @@ import {
   RequestOptions
 } from '@angular/http';
 
-import { DropdownModule, TooltipModule } from 'ng2-bootstrap';
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ModalModule } from 'ngx-modal';
 import { TreeModule } from 'angular2-tree-component';
 import {
@@ -44,6 +45,7 @@ let providers = [];
 
 if (process.env.ENV == 'inmemory') {
   providers = [
+    BsDropdownConfig,
     GlobalSettings,
     WorkItemService,
     Broadcaster,
@@ -53,10 +55,12 @@ if (process.env.ENV == 'inmemory') {
     {
       provide: HttpService,
       useClass: MockHttp
-    }
+    },
+    TooltipConfig
   ];
 } else {
   providers = [
+    BsDropdownConfig,
     GlobalSettings,
     WorkItemService,
     WorkItemDataService,
@@ -69,16 +73,17 @@ if (process.env.ENV == 'inmemory') {
         return new HttpService(backend, options, auth);
       },
       deps: [XHRBackend, RequestOptions, AuthenticationService]
-    }
+    },
+    TooltipConfig
   ];
 }
 
 @NgModule({
   imports: [
     AlmIconModule,
+    BsDropdownModule.forRoot(),
     CommonModule,
     DialogModule,
-    DropdownModule,
     FabPlannerAssociateIterationModalModule,
     HttpModule,
     InfiniteScrollModule,
@@ -87,7 +92,7 @@ if (process.env.ENV == 'inmemory') {
     PlannerListRoutingModule,
     SidepanelModule,
     ToolbarPanelModule,
-    TooltipModule,
+    TooltipModule.forRoot(),
     TreeModule,
     TreeListModule,
     WidgetsModule,

--- a/src/app/components/toolbar-panel/toolbar-panel.component.html
+++ b/src/app/components/toolbar-panel/toolbar-panel.component.html
@@ -1,26 +1,26 @@
 <header class="toolbar-header">
   <div class="width-100 pull-left">
-    <alm-toolbar
+    <pfng-toolbar
         [config]="toolbarConfig"
-        [actionsTemplate]="actionsTemplate"
-        [viewsTemplate]="addTemplate"
+        [actionTemplate]="actionsTemplate"
+        [viewTemplate]="addTemplate"
         (onFilterChange)="filterChange($event)"
-        (onFilterQueries)="filterQueries($event)"
-        (onFilterTypeChange)="selectFilterType($event)">
-      <template #actions>
-        <div *ngIf="context==='boardview' && (wiTypes.length!=0)" dropdown class="card-pf-time-frame-filter board-type-dropdown">
+        (onFilterFieldSelect)="selectFilterType($event)"
+        (onFilterTypeAhead)="filterQueries($event)">
+      <template #actionsTemplate>
+        <div *ngIf="context==='boardview' && (wiTypes.length!=0)" dropdown class="card-pf-time-frame-filter board-type-dropdown dropdown">
           <span class="currently-showing">Currently showing:</span>
           <button dropdownToggle
               id="wi-board-type"
               type="button"
-              class="btn btn-default">
+              class="btn btn-default dropdown-toggle">
             <span class='dropdown-icon fa {{currentBoardType?.attributes?.icon}}'></span>
             <span class='dropdown-text'>
               {{currentBoardType?.attributes?.name}}
             </span>
             <span class="caret"></span>
           </button>
-          <ul id="wi-board-type-dropdown" class="dropdown-menu dropdown-ul" role="menu" dropdownMenu>
+          <ul id="wi-board-type-dropdown" class="dropdown-menu dropdown-ul" role="menu" *dropdownMenu>
             <li class="dropdown-li" *ngFor="let type of wiTypes;" (click)="onChangeBoardType(type)">
               <a>
                 <span class='dropdown-icon fa {{type?.attributes?.icon}}'></span>
@@ -29,17 +29,17 @@
             </li>
           </ul>
         </div>
-        <div *ngIf="context!=='boardview'" dropdown class="list-type-dropdown">
+        <div *ngIf="context!=='boardview'" dropdown class="list-type-dropdown dropdown">
           <button dropdownToggle
               id="wi-list-type"
               type="button"
-              class="btn btn-default">
+              class="btn btn-default dropdown-toggle">
             <span class='dropdown-text'>
               {{currentListType}}
             </span>
             <span class="caret"></span>
           </button>
-          <ul id="wi-list-type-dropdown" class="dropdown-menu dropdown-ul" role="menu" dropdownMenu>
+          <ul id="wi-list-type-dropdown" class="dropdown-menu dropdown-ul" role="menu" *dropdownMenu>
             <li class="dropdown-li" (click)="onChangeListType('Hierarchy')">
               <a>
                 <span class='dropdown-text'>Hierarchy</span>
@@ -76,13 +76,13 @@
         </span>
       -->
       </template>
-      <template #add>
+      <template #addTemplate>
         <div *ngIf="loggedIn && editEnabled && wiTypes.length"
           class="with-cursor-pointer" placement="bottom"
           tooltip="Add A Work Item" (click)="showDetailType($event)">
           <i class="pficon pficon-add-circle-o margin-top-4"></i>
         </div>
       </template>
-    </alm-toolbar>
+    </pfng-toolbar>
   </div>
 </header>

--- a/src/app/components/toolbar-panel/toolbar-panel.component.ts
+++ b/src/app/components/toolbar-panel/toolbar-panel.component.ts
@@ -20,12 +20,10 @@ import { WorkItemType } from '../../models/work-item-type';
 import { WorkItem } from '../../models/work-item';
 
 import {
-  AlmArrayFilter,
   FilterConfig,
   FilterEvent,
-  FilterField,
   ToolbarConfig
-} from 'ngx-widgets';
+} from 'patternfly-ng';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -34,9 +32,6 @@ import {
   styleUrls: ['./toolbar-panel.component.scss']
 })
 export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnChanges, OnDestroy {
-  @ViewChild('actions') actionsTemplate: TemplateRef<any>;
-  @ViewChild('add') addTemplate: TemplateRef<any>;
-
   @Input() context: string;
   @Input() wiTypes: WorkItemType[] = [];
   @Input() areas: AreaModel[] = [];
@@ -379,33 +374,33 @@ export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnChanges, 
     }
   }
 
-  selectFilterType(data) {
+  selectFilterType(event: FilterEvent) {
     const filterMap = this.getFilterMap();
-    if (Object.keys(filterMap).indexOf(data.id) > -1) {
-      const index = this.filterConfig.fields.findIndex(i => i.id === data.id);
+    if (Object.keys(filterMap).indexOf(event.field.id) > -1) {
+      const index = this.filterConfig.fields.findIndex(i => i.id === event.field.id);
       if (this.filterConfig.fields[index].queries.length === 0) {
         this.toolbarConfig.filterConfig.fields[index].queries = [
           this.loader
         ];
-        filterMap[data.id].datasource.subscribe(resp => {
-          if (filterMap[data.id].datamap(resp).primaryQueries.length) {
+        filterMap[event.field.id].datasource.subscribe(resp => {
+          if (filterMap[event.field.id].datamap(resp).primaryQueries.length) {
             this.toolbarConfig.filterConfig.fields[index].queries =
-              filterMap[data.id].datamap(resp).queries.length ? [
-                ...filterMap[data.id].datamap(resp).primaryQueries,
+              filterMap[event.field.id].datamap(resp).queries.length ? [
+                ...filterMap[event.field.id].datamap(resp).primaryQueries,
                 this.separator,
-                ...filterMap[data.id].datamap(resp).queries
-              ] : filterMap[data.id].datamap(resp).primaryQueries;
+                ...filterMap[event.field.id].datamap(resp).queries
+              ] : filterMap[event.field.id].datamap(resp).primaryQueries;
           } else {
-            this.toolbarConfig.filterConfig.fields[index].queries = filterMap[data.id].datamap(resp).queries;
+            this.toolbarConfig.filterConfig.fields[index].queries = filterMap[event.field.id].datamap(resp).queries;
           }
           this.savedFIlterFieldQueries[this.filterConfig.fields[index].id] = {};
-          this.savedFIlterFieldQueries[this.filterConfig.fields[index].id]['fixed'] = filterMap[data.id].datamap(resp).primaryQueries;
-          this.savedFIlterFieldQueries[this.filterConfig.fields[index].id]['filterable'] = filterMap[data.id].datamap(resp).queries;
+          this.savedFIlterFieldQueries[this.filterConfig.fields[index].id]['fixed'] = filterMap[event.field.id].datamap(resp).primaryQueries;
+          this.savedFIlterFieldQueries[this.filterConfig.fields[index].id]['filterable'] = filterMap[event.field.id].datamap(resp).queries;
         })
       } else if (this.filterConfig.fields[index].type === 'typeahead'){
         this.filterQueries({
-          text: '',
-          field: data
+          value: '',
+          field: event.field
         });
       }
     }
@@ -416,9 +411,9 @@ export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnChanges, 
    * from tool bar component
    * @param event
    */
-  filterQueries(event) {
+  filterQueries(event: FilterEvent) {
     const index = this.filterConfig.fields.findIndex(i => i.id === event.field.id);
-    let inp = event.text.trim();
+    let inp = event.value.trim();
 
     if (inp) {
       this.filterConfig.fields[index].queries = [

--- a/src/app/components/toolbar-panel/toolbar-panel.module.ts
+++ b/src/app/components/toolbar-panel/toolbar-panel.module.ts
@@ -1,13 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import {
-  ComponentLoaderFactory,
-  DropdownConfig,
-  DropdownModule,
-  PositioningService,
-  TooltipConfig
-} from 'ng2-bootstrap';
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 
 import { CollaboratorService } from '../../services/collaborator.service';
 import { FilterService } from '../../services/filter.service';
@@ -17,28 +12,28 @@ import { ToolbarPanelComponent } from './toolbar-panel.component';
 import {
   AlmEditableModule,
   AlmIconModule,
-  ToolbarModule,
   WidgetsModule
 } from 'ngx-widgets';
+
+import { ToolbarModule } from 'patternfly-ng';
 
 @NgModule({
   imports: [
     AlmEditableModule,
     AlmIconModule,
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     ToolbarModule,
+    TooltipModule.forRoot(),
     WidgetsModule
   ],
   declarations: [
     ToolbarPanelComponent
   ],
   providers: [
+    BsDropdownConfig,
     CollaboratorService,
     FilterService,
-    ComponentLoaderFactory,
-    DropdownConfig,
-    PositioningService,
     TooltipConfig,
     WorkItemService
   ],

--- a/src/app/components/work-item-comment/work-item-comment.component.html
+++ b/src/app/components/work-item-comment/work-item-comment.component.html
@@ -37,7 +37,7 @@
                 [src]="comment.relationships['created-by']?.data?.attributes?.imageURL | almAvatarSize:30"
                 />
             </div>
-            <div class="dropdown dropdown-kebab-pf pull-right" dropdown>
+            <div class="dropdown dropdown-kebab-pf pull-right dropdown" dropdown>
               <button *ngIf="loggedIn && (loggedInUser?.id === comment.relationships['created-by']?.data?.id)"
                       class="btn btn-link dropdown-toggle"
                       id="commentActionsKebab"
@@ -48,10 +48,9 @@
                       aria-expanded="true">
                 <span class="fa fa-ellipsis-v"></span>
               </button>
-              <ul *ngIf="loggedIn && (loggedInUser?.id === comment.relationships['created-by']?.data?.id)"
-                  class="dropdown-menu dropdown-menu-right"
+              <ul class="dropdown-menu-right dropdown-menu"
                   aria-labelledby="commentActionsKebab"
-                  dropdownMenu>
+                  *dropdownMenu>
                 <li><a (click)="openComment(comment.id)">Edit...</a></li>
                 <li><a (click)="confirmCommentDelete(comment)">Delete</a></li>
               </ul>

--- a/src/app/components/work-item-create/work-item-create.module.ts
+++ b/src/app/components/work-item-create/work-item-create.module.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { ModalModule } from 'ngx-modal';
-import { DropdownModule } from 'ng2-bootstrap';
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
 import { WorkItemService } from '../../services/work-item.service';
 import { WorkItemDetailAddTypeSelectorComponent } from './work-item-create.component';
@@ -16,6 +16,7 @@ import {
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
     ModalModule
   ],
@@ -24,6 +25,7 @@ import {
     WorkItemDetailAddTypeSelectorComponent
   ],
   providers: [
+    BsDropdownConfig,
     WorkItemService
   ],
   exports: [WorkItemDetailAddTypeSelectorComponent, WorkItemDetailAddTypeSelectorWidgetComponent]

--- a/src/app/components/work-item-detail/work-item-detail.component.html
+++ b/src/app/components/work-item-detail/work-item-detail.component.html
@@ -77,18 +77,18 @@
             </div>
 
             <div class="col-sm-3 wi-state-btn pull-right padding0">
-              <div dropdown class="card-pf-time-frame-filter detail-status-dropdown">
+              <div *ngIf="loggedIn" dropdown class="card-pf-time-frame-filter detail-status-dropdown dropdown">
                 <button dropdownToggle
                   id="wi-detail-state"
                   type="button"
-                  class="btn btn-default col-sm-12">
+                  class="btn btn-default col-sm-12 dropdown-toggle">
                   <span class='dropdown-icon' almIcon [iconType]="workItem.attributes['system.state']"></span>
                   <span class='dropdown-text'>
                     {{workItem.attributes['system.state']}}
                   </span>
                   <span *ngIf="loggedIn" class="caret pull-right"></span>
                 </button>
-                <ul *ngIf="loggedIn" id="wi-status-dropdown" class="dropdown-menu-right dropdown-ul" role="menu" dropdownMenu>
+                <ul id="wi-status-dropdown" class="dropdown-menu-right dropdown-ul dropdown-menu" role="menu" *dropdownMenu>
                   <li class="dropdown-li" (click)="onChangeState(state)"
                     *ngFor="let state of workItem.relationships?.baseType?.data?.attributes?.fields['system.state'].type.values;"
                   >

--- a/src/app/components/work-item-detail/work-item-detail.module.ts
+++ b/src/app/components/work-item-detail/work-item-detail.module.ts
@@ -4,9 +4,10 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule }  from '@angular/forms';
 import { HttpModule, Http }    from '@angular/http';
 
-import { CollapseModule, TooltipModule } from 'ng2-bootstrap';
+import { CollapseModule } from 'ng2-bootstrap';
 import { Ng2CompleterModule } from 'ng2-completer';
-import { DropdownModule } from 'ng2-bootstrap';
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 import { MyDatePickerModule } from 'mydatepicker';
 
 import { MockHttp } from '../../mock/mock-http';
@@ -37,13 +38,14 @@ import { WorkItemTypeControlService } from '../../services/work-item-type-contro
 let providers = [];
 
 if (process.env.ENV == 'inmemory') {
-  providers = [ AreaService, WorkItemTypeControlService, { provide: Http, useExisting: MockHttp } ];
+  providers = [ AreaService, BsDropdownConfig, TooltipConfig, WorkItemTypeControlService, { provide: Http, useExisting: MockHttp } ];
 } else {
-  providers = [ AreaService, WorkItemTypeControlService ];
+  providers = [ AreaService, BsDropdownConfig, TooltipConfig, WorkItemTypeControlService ];
 }
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     HttpModule,
     WidgetsModule,
     AlmIconModule,
@@ -51,9 +53,8 @@ if (process.env.ENV == 'inmemory') {
     ModalModule,
     CommonModule,
     CollapseModule,
-    DropdownModule,
     FormsModule,
-    TooltipModule,
+    TooltipModule.forRoot(),
     Ng2CompleterModule,
     ReactiveFormsModule,
     MyDatePickerModule,

--- a/src/app/components/work-item-iteration-modal/work-item-iteration-modal.module.ts
+++ b/src/app/components/work-item-iteration-modal/work-item-iteration-modal.module.ts
@@ -3,10 +3,7 @@ import { NgModule }           from '@angular/core';
 import { CommonModule }       from '@angular/common';
 import { FormsModule }        from '@angular/forms';
 
-import {
-  DropdownConfig,
-  DropdownModule,
-} from 'ng2-bootstrap';
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import {
   WidgetsModule
 } from 'ngx-widgets';
@@ -17,8 +14,8 @@ import {
 
 @NgModule({
   imports: [
+    BsDropdownModule.forRoot(),
     CommonModule,
-    DropdownModule,
     FormsModule,
     ModalModule,
     WidgetsModule
@@ -29,7 +26,7 @@ import {
   ],
 
   providers: [
-    DropdownConfig
+    BsDropdownConfig
   ],
 
   exports: [

--- a/src/app/components/work-item-link/work-item-link.component.html
+++ b/src/app/components/work-item-link/work-item-link.component.html
@@ -65,13 +65,13 @@
           *ngIf="showLinkCreator">
           <div class="table-cell">
             <div class="combobox-container">
-              <div class="input-group" dropdown>
-                <input class="combobox form-control readonly"
+              <div *ngIf="linkTypes.length" class="input-group dropdown" dropdown>
+                <input class="combobox form-control readonly dropdown-toggle"
                   type="text" placeholder="Select Link Type"
                   [ngClass]="{'selected-value': selectedLinkType }"
                   readonly dropdownToggle
                   [attr.value]="selectedLinkType?.name">
-                <ul *ngIf="linkTypes.length" class="typeahead typeahead-long dropdown-menu" role="menu" dropdownMenu>
+                <ul class="typeahead typeahead-long dropdown-menu" role="menu" *dropdownMenu>
                   <li *ngFor="let linkType of selectedTab | workItemLinkTypeFilterByTypeName:(linkTypes)">
                     <a (click)="onSelectRelation(linkType)">{{linkType.name}}</a>
                   </li>

--- a/src/app/components/work-item-list-entry/work-item-list-entry.component.html
+++ b/src/app/components/work-item-list-entry/work-item-list-entry.component.html
@@ -39,11 +39,11 @@
 
 	<!-- action area -->
 	<div class="list-view-pf-actions" (click)="kebabClick($event)">
-		<div *ngIf="loggedIn" class="pull-right dropdown-kebab-pf" dropdown>
-			<button class="btn btn-link workItemList_dropdownKebabBtn" type="button" id="dropdownKebabRight" aria-haspopup="true" aria-expanded="true" dropdownToggle>
+		<div *ngIf="loggedIn" class="pull-right dropdown-kebab-pf dropdown" dropdown>
+			<button class="btn btn-link workItemList_dropdownKebabBtn dropdown-toggle" type="button" id="dropdownKebabRight" aria-haspopup="true" aria-expanded="true" dropdownToggle>
 				<span class="fa fa-ellipsis-v"></span>
 			</button>
-			<ul class="dropdown-menu-right" aria-labelledby="dropdownKebabRight" dropdownMenu>
+			<ul class="dropdown-menu-right dropdown-menu" aria-labelledby="dropdownKebabRight" *dropdownMenu>
 				<li><a class="workItemList_MoveTop" (click)="onMoveToTop($event)">Move to Top</a></li>
 				<li><a class="workItemList_MoveBottom" (click)="onMoveToBottom($event)">Move to Bottom</a></li>
 				<li role="presentation" class="divider"></li>

--- a/src/app/components/work-item-quick-add/work-item-quick-add.component.html
+++ b/src/app/components/work-item-quick-add/work-item-quick-add.component.html
@@ -24,7 +24,7 @@
       <ul class="dropdown-menu"
         role="menu"
         aria-labelledby="dropdownKebab"
-        dropdownMenu>
+        *dropdownMenu>
         <li *ngFor="let type of availableTypes"
           (click)="selectType($event, type)">
           <a class="dropdown-item" href="#" role="menuitem">

--- a/src/app/components/work-item-quick-add/work-item-quick-add.module.ts
+++ b/src/app/components/work-item-quick-add/work-item-quick-add.module.ts
@@ -2,13 +2,14 @@ import { NgModule }           from '@angular/core';
 import { CommonModule }       from '@angular/common';
 import { FormsModule }        from '@angular/forms';
 
-import { DropdownModule } from 'ng2-bootstrap';
+import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
 import { WorkItemQuickAddComponent } from './work-item-quick-add.component';
 
 @NgModule({
-  imports:      [ CommonModule, FormsModule, DropdownModule ],
+  imports:      [ BsDropdownModule.forRoot(), CommonModule, FormsModule ],
   declarations: [ WorkItemQuickAddComponent ],
-  exports:      [ WorkItemQuickAddComponent ]
+  exports:      [ WorkItemQuickAddComponent ],
+  providers:    [ BsDropdownConfig ]
 })
 export class WorkItemQuickAddModule { }


### PR DESCRIPTION
This replaces components from ngx-widgets with patternfly-ng, including:

- The tooblar component
- The filter/sort components used by toolbar.

This also introduces the latest dropdown from ngx-bootstrap for compatibility with patternfly-ng.

See: https://github.com/fabric8-ui/fabric8-ui/pull/1738