### PR TITLE
Fix drop-up menu

### DIFF
--- a/src/app/components/work-item-quick-add/work-item-quick-add.component.html
+++ b/src/app/components/work-item-quick-add/work-item-quick-add.component.html
@@ -12,10 +12,9 @@
   <div class="col-md-12 col-sm-12 col-xs-12 addWorkItemBlk "
     *ngIf="showQuickAdd">
     <!-- type dropdown -->
-    <div class="dropup dropdown-kebab-pf pull-left" dropdown>
+    <div class="dropdown-kebab-pf pull-left" dropdown [dropup]="true">
       <button class="btn btn-default dropdown-toggle work-item-selector"
         type="button"
-        data-toggle="dropdown"
         dropdownToggle>
         <i class="fa pull-left"
           [ngClass]="selectedType?selectedType.attributes.icon:''"></i>
@@ -26,8 +25,9 @@
         aria-labelledby="dropdownKebab"
         *dropdownMenu>
         <li *ngFor="let type of availableTypes"
-          (click)="selectType($event, type)">
-          <a class="dropdown-item" href="#" role="menuitem">
+            role="menuitem"
+            (click)="selectType($event, type)">
+          <a class="dropdown-item" href="#">
             <i class="fa pull-left"
               [ngClass]="type.attributes.icon"></i>&nbsp;{{type.attributes.name}}
           </a>


### PR DESCRIPTION
Fixed the type selection drop-up menu in quick add section of the planner list page. In order for the menu to open, additional 'drop-up' formatting is needed with ngx-bootstrap.

Note the [dropup]="true" statement. We cannot simply add the style class ourselves.