### PR TITLE
fix(functests) stick to chrome driver 2.30 version

### DIFF
--- a/runtime/tests/docker-entrypoint.sh
+++ b/runtime/tests/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 
 echo -n Updating Webdriver and Selenium...
 webdriver-manager update
-webdriver-manager update --versions.chrome 2.24
+webdriver-manager update --versions.chrome 2.30
 
 ## FIXME: Firefox complains about a missing machine-id file. So I set a random one
 echo 8636d9aff3933f48b95ad94891cd1839 > /var/lib/dbus/machine-id

--- a/runtime/tests/run_functional_tests.sh
+++ b/runtime/tests/run_functional_tests.sh
@@ -10,7 +10,7 @@ OS=$(uname -a | awk '{print $1;}')
 
 # Download dependencies
 echo -n Updating Webdriver and Selenium...
-node_modules/protractor/bin/webdriver-manager update
+node_modules/protractor/bin/webdriver-manager update --versions.chrome 2.30
 # Start selenium server just for this test run
 echo -n Starting Webdriver and Selenium...
 (node_modules/protractor/bin/webdriver-manager --versions.chrome 2.30 start >>$LOGFILE 2>&1 &)

--- a/runtime/tests/run_functional_tests.sh
+++ b/runtime/tests/run_functional_tests.sh
@@ -13,7 +13,7 @@ echo -n Updating Webdriver and Selenium...
 node_modules/protractor/bin/webdriver-manager update
 # Start selenium server just for this test run
 echo -n Starting Webdriver and Selenium...
-(node_modules/protractor/bin/webdriver-manager start >>$LOGFILE 2>&1 &)
+(node_modules/protractor/bin/webdriver-manager --versions.chrome 2.30 start >>$LOGFILE 2>&1 &)
 # Wait for port 4444 to be listening connections
 if [ $OS = 'Darwin' ]
 then


### PR DESCRIPTION
As you can see in the job activity of planner PRs, all are failing in the funciontal tests cause a new version of the chrome driver is used 2.31. This version is most certainly the cause of this problem, so we'll stick to 2.30 version as done in the past.