### PR TITLE
feat(test): add page objects to detect category tabs

### DIFF
--- a/runtime/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
+++ b/runtime/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
@@ -735,7 +735,18 @@ class WorkItemListPage {
   clickOnIterationDropDown(){
     return element(by.id('iteration-select-dropdown'));
   }
-
+  get Portfolio (){
+    return element(by.id('portfolio'));
+  }
+  clickPortfolio  (){
+    return this.Portfolio.click();
+  }
+  get Requirements (){
+    return element(by.id('portfolio'));
+  }
+  clickRequirements  (){
+    return this.Requirements.click();
+  }
 }
 
 module.exports = WorkItemListPage;


### PR DESCRIPTION
Added page objects 'clickPortfolio' and 'clickRequirements' to click on category tabs in the planner left panel.