### PR TITLE
fix(runtime): Update ngx-widget version under runtime.

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -63,7 +63,7 @@
     "ngx-fabric8-wit": "6.18.8",
     "ngx-login-client": "0.6.32",
     "ngx-modal": "0.0.29",
-    "ngx-widgets": "1.1.1",
+    "ngx-widgets": "1.1.2",
     "reflect-metadata": "0.1.10",
     "rxjs": "5.2.0",
     "zone.js": "0.8.5",


### PR DESCRIPTION
The ngx-version needs to be updated under the runtime folder. The root package.json and runtime's package.json need to have the same ngx-widgets version.