### PR TITLE
fix(unit tests): Set karma typescript version to 3.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "karma-remap-coverage": "^0.1.4",
     "karma-safari-launcher": "1.0.0",
     "karma-sourcemap-loader": "0.3.7",
-    "karma-typescript": "^3.0.2",
+    "karma-typescript": "3.0.5",
     "karma-typescript-angular2-transform": "^1.0.0",
     "karma-typescript-es6-transform": "^1.0.1",
     "karma-webpack": "2.0.3",


### PR DESCRIPTION
Set karma typescript version to 3.0.5 which works with Typescript 2.3.

Planner unit tests were failing as we had set "karma-typescript": "^3.0.2". This would install 3.0.6 and this version uses the latest Typescript version (2.5.2).

3.0.3, 3.0.4 and 3.0.5 work with Typescript 2.3