### PR TITLE
fix(test): Make test results more verbose

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -110,6 +110,7 @@
     "husky": "0.13.3",
     "istanbul-instrumenter-loader": "2.0.0",
     "jasmine-core": "2.5.2",
+    "jasmine-spec-reporter": "4.2.1",
     "json-loader": "0.5.4",
     "karma": "1.5.0",
     "karma-chrome-launcher": "2.0.0",

--- a/runtime/tests/protractor.config.js
+++ b/runtime/tests/protractor.config.js
@@ -1,3 +1,5 @@
+let SpecReporter = require('jasmine-spec-reporter').SpecReporter;
+
 exports.config = {
     useAllAngular2AppRoots: true,
     getPageTimeout: 30000,
@@ -13,7 +15,9 @@ exports.config = {
         isVerbose: true,
         showColors: true,
         includeStackTrace: true,
-        defaultTimeoutInterval: 60000
+        defaultTimeoutInterval: 60000,
+        print: function () {
+        }
     },
 
     troubleshoot: true,
@@ -30,5 +34,17 @@ exports.config = {
       'chromeOptions': {
       'args': [ '--no-sandbox', '--window-workspace=1']
       }
+    },
+
+    onPrepare: function () {
+      jasmine.getEnv().addReporter(new SpecReporter({
+        spec: {
+          displayStacktrace: true,
+          displayDuration: true,
+        },
+        summary: {
+          displayDuration: true
+        }
+      }));
     }
 };


### PR DESCRIPTION
This PR improves the verbosity of test results using the `jasmine-spec-reporter`[1] module.
**Before**
![screenshot from 2017-09-20 23-43-25](https://user-images.githubusercontent.com/12949454/30660172-9edb553c-9e5d-11e7-930e-9f2e25f52437.png)

**Now**
![screenshot from 2017-09-20 23-33-07](https://user-images.githubusercontent.com/12949454/30659739-5d281374-9e5c-11e7-8e93-5d7f14951214.png)

[1] - https://github.com/bcaudan/jasmine-spec-reporter
