### PR TITLE
refactor(deploy): auth-strat parity with fabric8-services/fabric8-wit#1668

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,25 +18,42 @@ services:
       - "8088:8080"
     volumes:
       - ./runtime/dist:/dist:Z
+  auth:
+    container_name: fabric8-planner-auth
+    image: docker.io/fabric8/fabric8-auth:latest
+    entrypoint: bin/auth
+    depends_on:
+      - db-auth
+    environment:
+      AUTH_WIT_URL: "http://localhost:8080"
+      AUTH_KEYCLOAK_REALM: "fabric8-test"
+      AUTH_DEVELOPER_MODE_ENABLED: "true"
+    network_mode: "host"
+    ports:
+      - "8089:8089"
   core:
     container_name: fabric8-planner-core
     image: fabric8/fabric8-wit:latest
     entrypoint: bin/wit
     depends_on:
-      - db
+      - auth
     environment:
-      F8_POSTGRES_HOST: db
-      F8_DEVELOPER_MODE_ENABLED: 'true'
-    networks:
-      - default
+      F8_DEVELOPER_MODE_ENABLED: "true"
+      F8_AUTH_URL: "http://localhost:8089"
+    network_mode: "host"
     ports:
       - "8080:8080"
-  db:
-    container_name: fabric8-planner-db
+  db-auth:
+    container_name: fabric8-planner-db-auth
     image: registry.centos.org/postgresql/postgresql:9.5
-    ports:
-      - "5432:5432"
     environment:
       POSTGRESQL_ADMIN_PASSWORD: mysecretpassword
-    networks:
-      - default
+    ports:
+      - "5433:5432"
+  db-data:
+    container_name: fabric8-planner-db-data
+    image: registry.centos.org/postgresql/postgresql:9.5
+    environment:
+      POSTGRESQL_ADMIN_PASSWORD: mysecretpassword
+    ports:
+      - "5432:5432"


### PR DESCRIPTION
## Following up on #2121

This PR changes the orchestration of the Docker Compose stack to match the new auth strategy introduced in fabric8-services/fabric8-wit#1668. Going forward it'll be rather easier to use KC auth on `fabric8-test` realm using this strategy for testing and development.

### Known Issue

**TL;DR:** If wit/core fails to start with `$ docker-compose up`, just force a `$ docker-compose start core` on another terminal. This will continue the `stdout` on the former terminal and the later terminal can be closed after invoking the command.

**Longer version:** `core` image may fail to start most of the time because it expects the `auth` service to be already up and running. This can be somewhat handled with netcat polling scripts or various third-party tools like `wait-for-it` or `dockerize` etc. and even with multiple compose files as well (one to set the basics: DBs, auth; and another for core and planner).

But none of these solutions are very clean for my taste or resolves the actual issue of lacking a service discovery broker. They also fail to determine service `ready` state, barely discovering their `up/running` state.

Long term proper solutions for this:
- **From our side can be:** having base image with necessary services, deps, runtimes etc pre-configured
- **From docker's side can be:** having a directive for deployment-ordering OR a service discovery broker 