### PR TITLE
feat(deploy): run f8ui integrated planner on docker compose stack

### DIFF
--- a/docker-compose.f8ui.yml
+++ b/docker-compose.f8ui.yml
@@ -2,22 +2,15 @@ version: '3'
 
 services:
   planner:
-    build: .
-    container_name: fabric8-planner-runtime
-    image: fabric8-planner-runtime
+    container_name: fabric8-planner-platform
+    image: fabric8-planner-platform
     # command: npm run test:unit
-    environment:
-      FABRIC8_WIT_API_URL: http://localhost:8080/api/
-      FABRIC8_SSO_API_URL: https://sso.prod-preview.openshift.io/
-      FABRIC8_REALM: fabric8-test
     depends_on:
       - core
     networks:
       - default
     ports:
-      - "8088:8080"
-    volumes:
-      - ./runtime/dist:/dist
+      - "8088:80"
   auth:
     container_name: fabric8-planner-auth
     image: docker.io/fabric8/fabric8-auth:latest

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -99,9 +99,9 @@ docker exec -u root fabric8-ui-builder npm run build:prod
 
 echo "Copy over the build artifacts from container to host..."
 echo ""
-echo "This is only needed because the platform build executes `npm run clean`"
-echo "which removes the `dist` directory from the host, unlinking the volume"
-docker cp fabric8-ui-builder:/home/fabric8/fabric8-ui/dist /tmp/platform/
+echo "This is only needed because the platform build executes 'npm run clean'"
+echo "which removes the 'dist' directory from the host, unlinking the volume"
+docker exec -u root fabric8-ui-builder cp -r /home/fabric8/fabric8-ui/dist $PLATFORMPATH/
 
 echo "Generating f8ui integrated planner image from build artifacts..."
 docker rm fabric8-planner-platform
@@ -113,5 +113,5 @@ docker stop fabric8-ui-builder
 docker rm fabric8-ui-builder
 docker rmi fabric8-ui-builder
 
-echo "Running the container; visit http://localhost:8080/ on host browser..."
-docker run -it --user=root -p 8080:80 --name=fabric8-planner-platform fabric8-planner-platform
+# echo "Running the container; visit http://localhost:8080/ on host browser..."
+# docker run -it --user=root -p 8080:80 --name=fabric8-planner-platform fabric8-planner-platform

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,21 +1,74 @@
 #!/bin/bash
 set -x
 
-echo "Setting up paths and working directories..."
+echo "Setting up working directories..."
 BASEPATH=`pwd -P`
-PLANNERPATH="$BASEPATH/planner"
-PLATFORMPATH="$BASEPATH/platform"
+PLANNERPATH=""
+PLATFORMPATH=""
 
-# echo "Setting up some environment variables, which ideally should be set in app as defaults..."
-# export FABRIC8_WIT_API_URL="https://api.prod-preview.openshift.io/api/"
-# export FABRIC8_RECOMMENDER_API_URL="https://api-bayesian.dev.rdu2c.fabric8.io/api/v1/"
-# export FABRIC8_FORGE_API_URL="https://forge.api.prod-preview.openshift.io"
-# export FABRIC8_SSO_API_URL="https://sso.prod-preview.openshift.io/"
-# export FABRIC8_REALM="fabric8-test"
+echo "Parsing CLI arguments..."
+for i in "$@"
+do
+case $i in
+    --planner=* )
+        if [[ -d "${i#*=}" ]]; then
+            # Provided path _is_ indeed a directory
+            cd ${i#*=}
+            # Let's validate if it contains the Planner source code
+            if [[ $(npm view . name) = fabric8-planner ]]; then
+                # The path seems to contain package.json which reports to be Planner source
+                PLANNERPATH=${i#*=}
+                echo "Planner path is set to: $PLANNERPATH"
+            else
+                echo -e "\e[1;31mCan't resolve source at provided Planner path\e[0m"
+                exit 1
+            fi
+        else
+            echo -e "\e[1;31mProvided Planner path is invalid\e[0m"
+            exit 1
+        fi
+        shift;;
+    --platform=* )
+        if [[ -d "${i#*=}" ]]; then
+            # Provided path _is_ indeed a directory
+            cd ${i#*=}
+            # Let's validate if it contains the Platform source code
+            if [[ $(npm view . name) = fabric8-ui ]]; then
+                # The path seems to contain package.json which reports to be Platform source
+                PLATFORMPATH=${i#*=}
+                echo "Platform path is set to: $PLATFORMPATH"
+            else
+                echo -e "\e[1;31mCan't resolve source at provided Platform path\e[0m"
+                exit 1
+            fi
+        else
+            echo -e "\e[1;31mProvided Platform path is invalid\e[0m"
+            exit 1
+        fi
+        shift;;
+    * )
+        ;;
+esac
+done
 
-echo "Downloading sources..."
-git clone https://github.com/fabric8-ui/fabric8-planner.git planner
-git clone https://github.com/fabric8-ui/fabric8-ui.git platform
+echo "Validating repositories..."
+if [[ -z $PLANNERPATH ]]; then
+    echo "Local Planner repo path wasn't provided, cloning from upstream to '/tmp/planner':"
+    PLANNERPATH=/tmp/planner
+    git clone https://github.com/fabric8-ui/fabric8-planner.git $PLANNERPATH
+fi
+if [[ -z $PLATFORMPATH ]]; then
+    echo "Local Platform repo path wasn't provided, cloning from upstream to '/tmp/platform':"
+    PLATFORMPATH=/tmp/platform
+    git clone https://github.com/fabric8-ui/fabric8-ui.git $PLATFORMPATH
+fi
+
+echo "Setting up some environment variables, which ideally should be set in app as defaults..."
+export FABRIC8_WIT_API_URL="https://api.prod-preview.openshift.io/api/"
+export FABRIC8_RECOMMENDER_API_URL="https://api-bayesian.dev.rdu2c.fabric8.io/api/v1/"
+export FABRIC8_FORGE_API_URL="https://forge.api.prod-preview.openshift.io"
+export FABRIC8_SSO_API_URL="https://sso.prod-preview.openshift.io/"
+export FABRIC8_REALM="fabric8-test"
 
 echo "Installing global prerequisites..."
 npm install -g rimraf gulp webpack webpack-merge
@@ -30,11 +83,12 @@ service docker start
 
 echo "Switching over to f8ui..."
 cd $PLATFORMPATH
-mkdir -p dist
 
 echo "Making f8ui-builder image and starting the container..."
+docker stop fabric8-ui-builder && docker rm fabric8-ui-builder
+docker rmi fabric8-ui-builder
 docker build -t fabric8-ui-builder -f Dockerfile.builder .
-docker run -d --name=fabric8-ui-builder -t -v $(pwd)/dist:/dist -v $(pwd)/../planner/dist:/planner -e FABRIC8_BRANDING=openshiftio -e FABRIC8_REALM=fabric8 fabric8-ui-builder
+docker run -d --name=fabric8-ui-builder -t -v $PLATFORMPATH/dist:/dist -v $PLANNERPATH/dist:/planner fabric8-ui-builder
 
 echo "Linking planner to platform within f8ui build container..."
 docker exec -u root fabric8-ui-builder npm install
@@ -43,14 +97,21 @@ docker exec -u root fabric8-ui-builder npm link /planner
 echo "Building platform with integrated planner..."
 docker exec -u root fabric8-ui-builder npm run build:prod
 
-# echo "Copy over the build artifacts from container to host..."
-# echo ""
-# echo "This is only needed if `npm run clean` was performed,"
-# echo "which removes the `dist` directory from host, unlinking the volume"
-# docker exec -u root fabric8-ui-builder cp -r ./dist /
+echo "Copy over the build artifacts from container to host..."
+echo ""
+echo "This is only needed because the platform build executes `npm run clean`"
+echo "which removes the `dist` directory from the host, unlinking the volume"
+docker cp fabric8-ui-builder:/home/fabric8/fabric8-ui/dist /tmp/platform/
 
 echo "Generating f8ui integrated planner image from build artifacts..."
+docker rm fabric8-planner-platform
+docker rmi fabric8-planner-platform
 docker build -t fabric8-planner-platform .
 
-# echo "Run the container, and visit http://localhost:8080/ on host browser..."
-# docker run -it --user=root -p 8080:80 --name=fabric8-planner-platform fabric8-planner-platform
+echo "Cleaning up intermediate build container and image..."
+docker stop fabric8-ui-builder
+docker rm fabric8-ui-builder
+docker rmi fabric8-ui-builder
+
+echo "Running the container; visit http://localhost:8080/ on host browser..."
+docker run -it --user=root -p 8080:80 --name=fabric8-planner-platform fabric8-planner-platform

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -101,12 +101,12 @@ echo "Copy over the build artifacts from container to host..."
 echo ""
 echo "This is only needed because the platform build executes 'npm run clean'"
 echo "which removes the 'dist' directory from the host, unlinking the volume"
-docker exec -u root fabric8-ui-builder cp -r /home/fabric8/fabric8-ui/dist $PLATFORMPATH/
+docker cp fabric8-ui-builder:/home/fabric8/fabric8-ui/dist $PLATFORMPATH/
 
 echo "Generating f8ui integrated planner image from build artifacts..."
 docker rm fabric8-planner-platform
 docker rmi fabric8-planner-platform
-docker build -t fabric8-planner-platform .
+docker build -t fabric8-planner-platform -f Dockerfile.deploy .
 
 echo "Cleaning up intermediate build container and image..."
 docker stop fabric8-ui-builder

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -5,6 +5,7 @@ echo "Setting up working directories..."
 BASEPATH=`pwd -P`
 PLANNERPATH=""
 PLATFORMPATH=""
+DRYRUN=false
 
 echo "Parsing CLI arguments..."
 for i in "$@"
@@ -46,6 +47,9 @@ case $i in
             exit 1
         fi
         shift;;
+    --dryrun )
+        DRYRUN=true
+        shift;;
     * )
         ;;
 esac
@@ -73,10 +77,17 @@ export FABRIC8_REALM="fabric8-test"
 echo "Installing global prerequisites..."
 npm install -g rimraf gulp webpack webpack-merge
 
-echo "Building planner library..."
 cd $PLANNERPATH
-npm install
-npm run build:library
+if [[ $DRYRUN = true ]]
+then
+    echo "Dry running mock build (bypasses actual build step)..."
+    mkdir -p dist
+    cp package.json dist/
+else
+    echo "Building planner library..."
+    npm install
+    npm run build:library
+fi
 
 echo "Starting docker..."
 service docker start
@@ -84,34 +95,56 @@ service docker start
 echo "Switching over to f8ui..."
 cd $PLATFORMPATH
 
-echo "Making f8ui-builder image and starting the container..."
-docker stop fabric8-ui-builder && docker rm fabric8-ui-builder
-docker rmi fabric8-ui-builder
-docker build -t fabric8-ui-builder -f Dockerfile.builder .
-docker run -d --name=fabric8-ui-builder -t -v $PLATFORMPATH/dist:/dist -v $PLANNERPATH/dist:/planner fabric8-ui-builder
+# echo "Making f8ui-builder image and starting the container..."
+# docker stop fabric8-ui-builder && docker rm fabric8-ui-builder
+# docker rmi fabric8-ui-builder
+# docker build -t fabric8-ui-builder -f Dockerfile.builder .
+# docker run -d --name=fabric8-ui-builder -t -v $PLATFORMPATH/dist:/dist -v $PLANNERPATH/dist:/planner fabric8-ui-builder
 
-echo "Linking planner to platform within f8ui build container..."
-docker exec -u root fabric8-ui-builder npm install
-docker exec -u root fabric8-ui-builder npm link /planner
 
-echo "Building platform with integrated planner..."
-docker exec -u root fabric8-ui-builder npm run build:prod
+# if [[ $DRYRUN = true ]]
+# then
+#     echo "Dry running mock build (bypasses actual build step)..."
+#     docker exec -u root fabric8-ui-builder echo 'Mock Build' > ./dist/index.html
+# else
+#     echo "Linking planner to platform within f8ui build container..."
+#     docker exec -u root fabric8-ui-builder npm install
+#     docker exec -u root fabric8-ui-builder npm link /planner
 
-echo "Copy over the build artifacts from container to host..."
-echo ""
-echo "This is only needed because the platform build executes 'npm run clean'"
-echo "which removes the 'dist' directory from the host, unlinking the volume"
-docker cp fabric8-ui-builder:/home/fabric8/fabric8-ui/dist $PLATFORMPATH/
+#     echo "Building platform with integrated planner..."
+#     docker exec -u root fabric8-ui-builder npm run build:prod
+# fi
+
+# echo "Copy over the build artifacts from container to host..."
+# echo ""
+# echo "This is only needed because the platform build executes 'npm run clean'"
+# echo "which removes the 'dist' directory from the host, unlinking the volume"
+# docker cp fabric8-ui-builder:/home/fabric8/fabric8-ui/dist $PLATFORMPATH/
+
+echo "Alternate build step, without using builder image, similar to f8ui/release.groovy..."
+if [[ $DRYRUN = true ]]
+then
+    echo "Dry running mock build (bypasses actual build step)..."
+    mkdir -p dist
+    echo 'Mock Build' > ./dist/index.html
+else
+    echo "Linking planner to platform within f8ui build container..."
+    npm install
+    npm link $PLANNERPATH/dist
+
+    echo "Building platform with integrated planner..."
+    npm run build:prod
+fi
 
 echo "Generating f8ui integrated planner image from build artifacts..."
 docker rm fabric8-planner-platform
 docker rmi fabric8-planner-platform
-docker build -t fabric8-planner-platform -f Dockerfile.deploy .
+docker build -t fabric8-planner-platform -f Dockerfile .
 
-echo "Cleaning up intermediate build container and image..."
-docker stop fabric8-ui-builder
-docker rm fabric8-ui-builder
-docker rmi fabric8-ui-builder
+# echo "Cleaning up intermediate build container and image..."
+# docker stop fabric8-ui-builder
+# docker rm fabric8-ui-builder
+# docker rmi fabric8-ui-builder
 
 # echo "Running the container; visit http://localhost:8080/ on host browser..."
 # docker run -it --user=root -p 8080:80 --name=fabric8-planner-platform fabric8-planner-platform

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -x
+
+echo "Setting up paths and working directories..."
+BASEPATH=`pwd -P`
+PLANNERPATH="$BASEPATH/planner"
+PLATFORMPATH="$BASEPATH/platform"
+
+# echo "Setting up some environment variables, which ideally should be set in app as defaults..."
+# export FABRIC8_WIT_API_URL="https://api.prod-preview.openshift.io/api/"
+# export FABRIC8_RECOMMENDER_API_URL="https://api-bayesian.dev.rdu2c.fabric8.io/api/v1/"
+# export FABRIC8_FORGE_API_URL="https://forge.api.prod-preview.openshift.io"
+# export FABRIC8_SSO_API_URL="https://sso.prod-preview.openshift.io/"
+# export FABRIC8_REALM="fabric8-test"
+
+echo "Downloading sources..."
+git clone https://github.com/fabric8-ui/fabric8-planner.git planner
+git clone https://github.com/fabric8-ui/fabric8-ui.git platform
+
+echo "Installing global prerequisites..."
+npm install -g rimraf gulp webpack webpack-merge
+
+echo "Building planner library..."
+cd $PLANNERPATH
+npm install
+npm run build:library
+
+echo "Starting docker..."
+service docker start
+
+echo "Switching over to f8ui..."
+cd $PLATFORMPATH
+mkdir -p dist
+
+echo "Making f8ui-builder image and starting the container..."
+docker build -t fabric8-ui-builder -f Dockerfile.builder .
+docker run -d --name=fabric8-ui-builder -t -v $(pwd)/dist:/dist -v $(pwd)/../planner/dist:/planner -e FABRIC8_BRANDING=openshiftio -e FABRIC8_REALM=fabric8 fabric8-ui-builder
+
+echo "Linking planner to platform within f8ui build container..."
+docker exec -u root fabric8-ui-builder npm install
+docker exec -u root fabric8-ui-builder npm link /planner
+
+echo "Building platform with integrated planner..."
+docker exec -u root fabric8-ui-builder npm run build:prod
+
+# echo "Copy over the build artifacts from container to host..."
+# echo ""
+# echo "This is only needed if `npm run clean` was performed,"
+# echo "which removes the `dist` directory from host, unlinking the volume"
+# docker exec -u root fabric8-ui-builder cp -r ./dist /
+
+echo "Generating f8ui integrated planner image from build artifacts..."
+docker build -t fabric8-planner-platform .
+
+# echo "Run the container, and visit http://localhost:8080/ on host browser..."
+# docker run -it --user=root -p 8080:80 --name=fabric8-planner-platform fabric8-planner-platform


### PR DESCRIPTION
Integration build with upstream source(s):
```bash
cd /path/to/planner/repo
./scripts/bootstrap.sh
```

Integration build with local source(s):
```bash
bootstrap.sh --planner=/full/path/to/planner --platform=/full/path/to/platform
# it's okay to provide local path to both repos, either repo or none
# if path was not provided to either, that repo will be cloned from upstream
```

To ignore builds and dry-run the orchestration, use `--dryrun` flag:
```bash
bootstrap.sh --dryrun
# skips building planner library and f8ui
# generates a mock index.html file
```

N.B: depends on fabric8-ui/fabric8-ui#2178 to function.