### PR TITLE
fix(test): Refactor clickWorkitemTitle method

### DIFF
--- a/runtime/src/tests/work-item/work-item-list/area.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/area.spec.js
@@ -11,8 +11,7 @@
 
 var WorkItemListPage = require('./page-objects/work-item-list.page'),
   constants = require('./constants'),
-  testSupport = require('./testSupport'),
-  WorkItemDetailPage = require('./page-objects/work-item-detail.page');
+  testSupport = require('./testSupport');
 
 describe('Area tests :: ', function () {
   var page; 
@@ -31,13 +30,13 @@ describe('Area tests :: ', function () {
   });
 
   it('Verify Area elements are present -desktop ', function() {
-      detailPage = page.clickWorkItemTitle(page.firstWorkItem, WORKITEM_0_ID);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       browser.wait(until.elementToBeClickable(detailPage.areaLabel), constants.WAIT, 'Failed to find areaLabel');   
       expect(detailPage.AreaSelect().isPresent()).toBe(true);
      });
 
   it('Adding area to a WI -desktop ', function() {
-      detailPage = page.clickWorkItemTitle(page.firstWorkItem, WORKITEM_0_ID);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       browser.wait(until.elementToBeClickable(detailPage.areaLabel), constants.WAIT, 'Failed to find areaLabel');   
       detailPage.clickAreaSelect();
       detailPage.clickAreas(WORKITEM_0_ID);
@@ -49,7 +48,7 @@ describe('Area tests :: ', function () {
      });
 
   it('Updating area to a WI -desktop ', function() {
-      detailPage = page.clickWorkItemTitle(page.firstWorkItem, WORKITEM_0_ID);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       browser.wait(until.elementToBeClickable(detailPage.areaLabel), constants.WAIT, 'Failed to find areaLabel');   
       detailPage.clickAreaSelect();
       detailPage.clickAreas(WORKITEM_0_ID);
@@ -67,7 +66,7 @@ describe('Area tests :: ', function () {
      });
 
     it('Try Removing area from a WI -desktop ', function() {
-      detailPage = page.clickWorkItemTitle(page.firstWorkItem, WORKITEM_0_ID);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       browser.wait(until.elementToBeClickable(detailPage.areaLabel), constants.WAIT, 'Failed to find areaLabel');   
       detailPage.clickAreaSelect();
       detailPage.clickAreas(WORKITEM_0_ID);

--- a/runtime/src/tests/work-item/work-item-list/assign.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/assign.spec.js
@@ -19,7 +19,7 @@ var WorkItemListPage = require('./page-objects/work-item-list.page'),
   testSupport = require('./testSupport');
 
 describe('Work item list', function () {
-  var page; 
+  var page;
   var until = protractor.ExpectedConditions;
   var workItemTitle = "The test workitem title";
   var workItemUpdatedTitle = "The test workitem title - UPDATED";
@@ -39,7 +39,7 @@ describe('Work item list', function () {
     page.typeQuickAddWorkItemTitle(workItemTitle);
     page.clickQuickAddSave(); 
     page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-      var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
 
       browser.wait(until.elementToBeClickable(detailPage.workItemDetailAssigneeIcon), constants.WAIT, 'Failed to find Assignee Icon');   
       detailPage.clickworkItemDetailAssigneeIcon();
@@ -67,7 +67,7 @@ describe('Work item list', function () {
       page.typeQuickAddWorkItemTitle(workItemTitle);
       page.clickQuickAddSave().then(function() {
       page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-        var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+        var detailPage = page.clickWorkItem(page.firstWorkItem);
 
         browser.wait(until.elementToBeClickable(detailPage.workItemDetailAssigneeIcon), constants.WAIT, 'Failed to find Assignee Icon');   
         expect(detailPage.clickworkItemDetailAssigneeIcon()).toBe(null);
@@ -89,7 +89,7 @@ describe('Work item list', function () {
       page.typeQuickAddWorkItemTitle(workItemTitle);
       page.clickQuickAddSave();
       page.workItemViewId(page.firstWorkItem).getText().then(function (text) { 
-        var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+        var detailPage = page.clickWorkItem(page.firstWorkItem);
 
         browser.wait(until.elementToBeClickable(detailPage.workItemDetailAssigneeIcon), constants.WAIT, 'Failed to find Assignee Icon');   
         detailPage.clickworkItemDetailAssigneeIcon();
@@ -120,7 +120,7 @@ describe('Work item list', function () {
       page.typeQuickAddWorkItemTitle(workItemTitle);
       page.clickQuickAddSave().then(function() {
       page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-        var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+        var detailPage = page.clickWorkItem(page.firstWorkItem);
 
         browser.wait(until.elementToBeClickable(detailPage.workItemDetailAssigneeIcon), constants.WAIT, 'Failed to find Assignee Icon');   
         detailPage.clickworkItemDetailAssigneeIcon();
@@ -145,7 +145,7 @@ describe('Work item list', function () {
       page.typeQuickAddWorkItemTitle(workItemTitle);
       page.clickQuickAddSave().then(function() {
       page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-        var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+        var detailPage = page.clickWorkItem(page.firstWorkItem);
 
         browser.wait(until.elementToBeClickable(detailPage.workItemDetailAssigneeIcon), constants.WAIT, 'Failed to find Assignee Icon');   
         detailPage.clickworkItemDetailAssigneeIcon();
@@ -178,7 +178,7 @@ describe('Work item list', function () {
       page.typeQuickAddWorkItemTitle(workItemTitle);
       page.clickQuickAddSave().then(function() {
       page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-        var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+        var detailPage = page.clickWorkItem(page.firstWorkItem);
 
         browser.wait(until.elementToBeClickable(detailPage.workItemDetailAssigneeIcon), constants.WAIT, 'Failed to find Assignee Icon');   
         detailPage.clickworkItemDetailAssigneeIcon();
@@ -207,7 +207,7 @@ describe('Work item list', function () {
       page.typeQuickAddWorkItemTitle(workItemTitle);
       page.clickQuickAddSave();
       page.workItemViewId(page.firstWorkItem).getText().then(function (text) { 
-        var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+        var detailPage = page.clickWorkItem(page.firstWorkItem);
 
         browser.wait(until.elementToBeClickable(detailPage.workItemDetailAssigneeIcon), constants.WAIT, 'Failed to find Assignee Icon');   
         detailPage.clickworkItemDetailAssigneeIcon();
@@ -229,7 +229,7 @@ describe('Work item list', function () {
       page.typeQuickAddWorkItemTitle(workItemTitle);
       page.clickQuickAddSave();
       page.workItemViewId(page.firstWorkItem).getText().then(function (text) { 
-        var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+        var detailPage = page.clickWorkItem(page.firstWorkItem);
 
         browser.wait(until.elementToBeClickable(detailPage.workItemDetailAssigneeIcon), constants.WAIT, 'Failed to find Assignee Icon');   
         detailPage.clickworkItemDetailAssigneeIcon();

--- a/runtime/src/tests/work-item/work-item-list/basicAssignFilter.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/basicAssignFilter.spec.js
@@ -19,7 +19,6 @@
 
 var WorkItemListPage = require('./page-objects/work-item-list.page'),
   testSupport = require('./testSupport'),
-  WorkItemDetailPage = require('./page-objects/work-item-detail.page'),
   CommonPage = require('./page-objects/common.page'),
   constants = require('./constants');
 
@@ -52,7 +51,7 @@ describe('Basic filter workitems by assignee Test', function () {
       page.typeQuickAddWorkItemTitle(WORK_ITEM_TITLE);
       page.clickQuickAddSave().then(function() {
         page.workItemViewId(page.workItemByTitle(WORK_ITEM_TITLE)).getText().then(function (text) {
-          var detailPage = page.clickWorkItemTitle(page.workItemByTitle(WORK_ITEM_TITLE), text);
+          var detailPage = page.clickWorkItemTitle(WORK_ITEM_TITLE);
           expect(detailPage.details_assigned_user().getText()).toContain(EXAMPLE_USER_0_VERIFY);
           detailPage.clickWorkItemDetailCloseButton();
         })
@@ -73,7 +72,7 @@ describe('Basic filter workitems by assignee Test', function () {
       page.typeQuickAddWorkItemTitle(WORK_ITEM_TITLE);
       page.clickQuickAddSave().then(function() {
         page.workItemViewId(page.workItemByTitle(WORK_ITEM_TITLE)).getText().then(function (text) {
-          var detailPage = page.clickWorkItemTitle(page.workItemByTitle(WORK_ITEM_TITLE), text);
+          var detailPage = page.clickWorkItemTitle(WORK_ITEM_TITLE);
           expect(detailPage.AreaSelect().getText()).toContain(AREA_0_TITLE);
           detailPage.clickWorkItemDetailCloseButton();
         })

--- a/runtime/src/tests/work-item/work-item-list/comments.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/comments.spec.js
@@ -12,7 +12,7 @@
 var WorkItemListPage = require('./page-objects/work-item-list.page'),
   constants = require('./constants'),
   testSupport = require('./testSupport');
-  WorkItemDetailPage = require('./page-objects/work-item-detail.page'),
+
 describe('Comments tests :: ', function () {
   var page, items, browserMode;
 
@@ -22,12 +22,11 @@ var waitTime = 30000;
   beforeEach(function () {
     testSupport.setBrowserMode('desktop');
     page = new WorkItemListPage(true);
-    detailPage = new WorkItemDetailPage(true);
     testSupport.setTestSpace(page);
   });
 
   it('Verify comments text area, username, comment,time is present -desktop ', function() {
-    page.clickWorkItemTitle(page.firstWorkItem, "id0");
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     detailPage.clickCommentIcon();
     detailPage.clickCommentDiv();
     detailPage.clickActiveCommentEditorBox();

--- a/runtime/src/tests/work-item/work-item-list/displayAndUpdateWorkItemDetails.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/displayAndUpdateWorkItemDetails.spec.js
@@ -46,7 +46,7 @@ var waitTime = 30000;
       /* Fill in/update the new work item's title and details field */
       expect(page.workItemTitle(page.firstWorkItem)).toBe(workItemTitle);
       page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-        var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+        var detailPage = page.clickWorkItem(page.firstWorkItem);
 
         detailPage.clickWorkItemTitleDiv();
         detailPage.setWorkItemDetailTitle (workItemUpdatedTitle, false);
@@ -78,7 +78,7 @@ var waitTime = 30000;
       expect(page.workItemTitle(page.workItemByTitle(workItemTitle))).toBe(workItemTitle);
 
       page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-        var detailPage = page.clickWorkItemTitle(page.workItemByTitle(workItemTitle), text);
+        var detailPage = page.clickWorkItemTitle(workItemTitle);
         detailPage.clickWorkItemDetailTitleClick();
         detailPage.setWorkItemDetailTitle (workItemUpdatedTitle, false);
         detailPage.clickWorkItemTitleSaveIcon();
@@ -114,7 +114,7 @@ var waitTime = 30000;
 
       /* Fill in/update the new work item's title and details field */
       page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-        var detailPage = page.clickWorkItemTitle(page.workItemByTitle(workItemTitle), text);
+        var detailPage = page.clickWorkItemTitle(workItemTitle);
         detailPage.clickWorkItemDetailTitleClick();
 
         detailPage.setWorkItemDetailTitle (workItemUpdatedTitle, false);
@@ -149,7 +149,7 @@ var waitTime = 30000;
         /* Fill in/update the new work item's title with blank and details field */
         expect(page.workItemTitle(page.firstWorkItem)).toBe(workItemTitle);
         page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-          var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+          var detailPage = page.clickWorkItem(page.firstWorkItem);
 
           detailPage.clickWorkItemTitleDiv();
           detailPage.setWorkItemDetailTitle (workItemUpdatedTitle, false);
@@ -178,7 +178,7 @@ var waitTime = 30000;
 
       /* Fill in/update the new work item's title with blank and details field */
       page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-        var detailPage = page.clickWorkItemTitle(page.workItemByTitle(workItemTitle), text);
+        var detailPage = page.clickWorkItemTitle(workItemTitle);
         detailPage.clickWorkItemDetailTitleClick();
         detailPage.setWorkItemDetailTitle(workItemUpdatedTitle, false);
         detailPage.clickWorkItemTitleSaveIcon();
@@ -208,7 +208,7 @@ var waitTime = 30000;
 
           /* Fill in/update the new work item's title with blank and details field */
           page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-            var detailPage = page.clickWorkItemTitle(page.workItemByTitle(workItemTitle), text);
+            var detailPage = page.clickWorkItemTitle(workItemTitle);
             detailPage.clickWorkItemDetailTitleClick();
 
             detailPage.setWorkItemDetailTitle(workItemUpdatedTitle, false);
@@ -298,7 +298,7 @@ it('Verify how many work item type exists in drop down - desktop', function() {
       page.typeQuickAddWorkItemTitle(workItemTitle);
       page.clickQuickAddSave().then(function() {
          page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-          var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+          var detailPage = page.clickWorkItem(page.firstWorkItem);
           /*Commenting type drop down related tests for issue 635
           detailPage.clickworkItemDetailTypeIcon();
           */
@@ -316,7 +316,7 @@ it('Verify how many work item type exists in drop down - desktop', function() {
 
          page.clickQuickAddSave().then(function() {
            page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-             var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+             var detailPage = page.clickWorkItem(page.firstWorkItem);
 //             expect(detailPage.WorkItemStateDropDownListCount()).toBe(5);
           });
          });
@@ -332,7 +332,7 @@ it('Verify how many work item type exists in drop down - desktop', function() {
           expect(page.workItemTitle(page.firstWorkItem)).toBe(workItemTitle);
           expect(page.workItemTitle(page.firstWorkItem)).toBe(workItemTitle);
           page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-          var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+          var detailPage = page.clickWorkItem(page.firstWorkItem);
 
           browser.wait(until.elementToBeClickable(detailPage.workItemStateDropDownButton), constants.WAIT, 'Failed to find workItemStateDropDownButton');   
           detailPage.clickWorkItemStateDropDownButton();
@@ -354,7 +354,7 @@ it('Verify how many work item type exists in drop down - desktop', function() {
          page.typeQuickAddWorkItemTitle(workItemTitle);
          page.clickQuickAddSave().then(function() {
          page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-         var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+         var detailPage = page.clickWorkItem(page.firstWorkItem);
 
          browser.wait(until.elementToBeClickable(detailPage.workItemStateDropDownButton), constants.WAIT, 'Failed to find workItemStateDropDownButton');   
          detailPage.clickWorkItemStateDropDownButton();
@@ -376,7 +376,7 @@ it('Verify how many work item type exists in drop down - desktop', function() {
       browser.wait(until.elementToBeClickable(page.workItemTitle(page.firstWorkItem)), constants.WAIT, 'Failed to find firstWorkItem');   
 
       page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-      var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
 
       browser.wait(until.elementToBeClickable(detailPage.workItemStateDropDownButton), constants.WAIT, 'Failed to find workItemStateDropDownButton');   
       detailPage.clickWorkItemStateDropDownButton();
@@ -395,7 +395,7 @@ it('Verify how many work item type exists in drop down - desktop', function() {
       page.typeQuickAddWorkItemTitle(workItemTitle);
       page.clickQuickAddSave().then(function() {
       page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-      var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
 
       browser.wait(until.elementToBeClickable(detailPage.workItemStateDropDownButton), constants.WAIT, 'Failed to find workItemStateDropDownButton');   
       detailPage.clickWorkItemStateDropDownButton();
@@ -414,7 +414,7 @@ it('Verify how many work item type exists in drop down - desktop', function() {
       page.typeQuickAddWorkItemTitle(workItemTitle);
       page.clickQuickAddSave().then(function() {
       page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-      var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
 
       browser.wait(until.elementToBeClickable(detailPage.workItemStateDropDownButton), constants.WAIT, 'Failed to find workItemStateDropDownButton');   
       detailPage.clickWorkItemStateDropDownButton();
@@ -442,7 +442,7 @@ it('Verify how many work item type exists in drop down - desktop', function() {
 
           /* Fill in/update the new work item's title with blank and details field */
           page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-            var detailPage = page.clickWorkItemTitle(page.workItemByTitle(workItemTitle), text);
+            var detailPage = page.clickWorkItemTitle(workItemTitle);
             detailPage.clickWorkItemDetailTitleClick();
 
             detailPage.setWorkItemDetailTitle(workItemUpdatedTitle, false);
@@ -460,7 +460,7 @@ it('Verify how many work item type exists in drop down - desktop', function() {
       page.typeQuickAddWorkItemTitle(workItemTitle);
       page.clickQuickAddSave();   
       
-      var detailPage = page.clickWorkItemTitle(page.firstWorkItem, workItemTitle);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       browser.wait(until.elementToBeClickable(page.workItemTitle(page.firstWorkItem)), constants.WAIT, 'Failed to find first work item on page');   
 
       detailPage.clickWorkItemDetailCloseButton();
@@ -475,7 +475,7 @@ it('Verify how many work item type exists in drop down - desktop', function() {
       page.typeQuickAddWorkItemDesc("describe");
       page.clickQuickAddSave(); 
       expect(page.workItemDescription(page.firstWorkItem)).toBe("");
-      var detailPage = page.clickWorkItemTitle(page.firstWorkItem, workItemTitle);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       browser.wait(until.elementToBeClickable(detailPage.clickWorkItemDetailDescription()), constants.WAIT, 'Failed to find Work Item Description');   
 
       detailPage.clickWorkItemDetailDescription();
@@ -483,7 +483,7 @@ it('Verify how many work item type exists in drop down - desktop', function() {
       detailPage.setWorkItemDetailDescription(" ",false);
       detailPage.clickWorkItemDescriptionSaveIcon();
       detailPage.clickWorkItemDetailCloseButton();
-      page.clickWorkItemTitle(page.firstWorkItem, workItemTitle);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       expect(page.workItemDescription(page.firstWorkItem)).toBe("");
     });
 
@@ -495,31 +495,30 @@ it('Verify how many work item type exists in drop down - desktop', function() {
       page.typeQuickAddWorkItemDesc("describe");
       page.clickQuickAddSave(); 
       expect(page.workItemDescription(page.firstWorkItem)).toBe("");
-      var detailPage = page.clickWorkItemTitle(page.firstWorkItem, workItemTitle);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       detailPage.clickWorkItemDetailDescription();
       detailPage.clickWorkItemDescriptionEditIcon();    
       detailPage.setWorkItemDetailDescription(" ",false);
       detailPage.clickWorkItemDescriptionSaveIcon();
       detailPage.clickWorkItemDetailCloseButton();
-      page.clickWorkItemTitle(page.firstWorkItem, workItemTitle);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       expect(page.workItemDescription(page.firstWorkItem)).toBe("");
     });
 
     it('Verify the HTML tags should be treated as text while writing description/title. - desktop ', function() { 
-      testSupport.setBrowserMode("desktop");
       var workItemTitle = "<title>Yes this is a title</title>";
       page.clickWorkItemQuickAdd();
       page.typeQuickAddWorkItemTitle(workItemTitle);
       page.typeQuickAddWorkItemDesc("describe");
-      page.clickQuickAddSave(); 
+      page.clickQuickAddSave();
       expect(page.workItemDescription(page.firstWorkItem)).toBe("");
-      var detailPage = page.clickWorkItemTitle(page.firstWorkItem, workItemTitle);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       detailPage.clickWorkItemDetailDescription();
       detailPage.clickWorkItemDescriptionEditIcon();      
       detailPage.setWorkItemDetailDescription(" ",false);
       detailPage.clickWorkItemDescriptionSaveIcon();
       detailPage.clickWorkItemDetailCloseButton();
-      page.clickWorkItemTitle(page.firstWorkItem, workItemTitle);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       expect(page.workItemDescription(page.firstWorkItem)).toBe("");
     });
 });

--- a/runtime/src/tests/work-item/work-item-list/iteration.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/iteration.spec.js
@@ -43,7 +43,6 @@ describe('Iteration CRUD tests :: ', function () {
       'FullPath' : '/Root Iteration/Iteration 1',
       'Index': 2
     },
-    firstWorkItemID = 'id0',
     updateIterationTitle = 'Update Iteration',
     updateIterationDescription = 'Update Iteration Description',
     childIterationTitle = 'New Child Iteration',
@@ -160,7 +159,7 @@ describe('Iteration CRUD tests :: ', function () {
 //  });
 
   it('Associate Workitem from detail page', function() {
-    var detailPage = page.clickWorkItemTitle(page.firstWorkItem, firstWorkItemID);
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     browser.wait(until.elementToBeClickable(detailPage.workItemStateDropDownButton), constants.WAIT, 'Failed to find workItemStateDropDownButton');
     detailPage.IterationOndetailPage().click();
     detailPage.associateIterationById(firstIteration.ID);
@@ -169,20 +168,20 @@ describe('Iteration CRUD tests :: ', function () {
     detailPage.clickWorkItemDetailCloseButton();
 
     // Reopen the same detail page and check changes are saved
-    var detailPage = page.clickWorkItemTitle(page.firstWorkItem, firstWorkItemID);
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     browser.wait(until.elementToBeClickable(detailPage.workItemStateDropDownButton), constants.WAIT, 'Failed to find workItemStateDropDownButton');
     expect(detailPage.getAssociatedIteration()).toBe(firstIteration.FullPath);
     detailPage.clickWorkItemDetailCloseButton();
   });
 
   it('Re-Associate Workitem from detail page', function() {
-    var detailPage = page.clickWorkItemTitle(page.firstWorkItem, firstWorkItemID);
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     detailPage.IterationOndetailPage().click();
     detailPage.associateIterationById(firstIteration.ID);
     detailPage.saveIteration();
 
     // Re - associate
-    page.clickWorkItemTitle(page.firstWorkItem, firstWorkItemID);
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     detailPage.IterationOndetailPage().click();
     detailPage.associateIterationById(secondIteration.ID);
     detailPage.saveIteration();
@@ -360,7 +359,7 @@ describe('Iteration CRUD tests :: ', function () {
   var setWorkItemStatus = function (thePage, theWorkItemTitle, theWorkItemStatus) {
     var until = protractor.ExpectedConditions;
     thePage.workItemViewId(thePage.workItemByTitle(theWorkItemTitle)).getText().then(function (text) {
-      var detailPage = thePage.clickWorkItemTitle(thePage.workItemByTitle(theWorkItemTitle), text);
+      var detailPage = thePage.clickWorkItemTitle(theWorkItemTitle);
       browser.wait(until.elementToBeClickable(detailPage.workItemStateDropDownButton), constants.WAIT, 'Failed to find workItemStateDropDownButton');   
       detailPage.clickWorkItemStateDropDownButton();
       browser.wait(until.elementToBeClickable(detailPage.WorkItemStateDropDownList().get(theWorkItemStatus)), constants.WAIT, 'Failed to find workItemStateDropDownButton');   

--- a/runtime/src/tests/work-item/work-item-list/labels.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/labels.spec.js
@@ -11,15 +11,11 @@
 
 var WorkItemListPage = require('./page-objects/work-item-list.page'),
 testSupport = require('./testSupport'),
-constants = require('./constants'),
-WorkItemDetailPage = require('./page-objects/work-item-detail.page');
+constants = require('./constants');
 
 describe('Labels CRUD Tests', function () {
-  var page, items, browserMode, detailPage,
+  var page, items, browserMode,
     until = protractor.ExpectedConditions,
-    firstitem = {
-      'id': 'id0',
-    },
     newLabelTitle = "My Test Label",
     defaultSelectedLableTitle = "Example Label 1",
     testLabelTitle1 = "Example Label 0",
@@ -32,7 +28,7 @@ describe('Labels CRUD Tests', function () {
   });
 
   it('Verify add label button exists', function(){
-    detailPage = page.clickWorkItemTitle(page.firstWorkItem, firstitem.id);
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     expect(detailPage.addLabelButton.isPresent()).toBeTruthy();
     expect(detailPage.selectLabelDropdown.isPresent()).toBeFalsy();
     detailPage.clickAddLabelButton();
@@ -41,13 +37,13 @@ describe('Labels CRUD Tests', function () {
   });
 
   it('Verify create new label button is clickable', function(){
-    detailPage = page.clickWorkItemTitle(page.firstWorkItem, firstitem.id);
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     let clickEvent = detailPage.clickAddLabelButton();
     expect(clickEvent).toBeDefined();
   });
 
   it('Verify create new Label', function(){
-    detailPage = page.clickWorkItemTitle(page.firstWorkItem, firstitem.id);
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     detailPage.clickAddLabelButton();
     let origLabelCount
     detailPage.labelsCount.then(function(count){
@@ -65,15 +61,10 @@ describe('Labels CRUD Tests', function () {
   })
 
   it('Verify adding existing labels', function(){
-    detailPage = page.clickWorkItemTitle(page.firstWorkItem,firstitem.id);
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     detailPage.clickAddLabelButton();
     detailPage.selectLabelByTitle(testLabelTitle1);
     detailPage.selectLabelByTitle(testLabelTitle2);
-
-    detailPage.attachedLabels().getText().then(function(text){
-      console.log ("LABEL TEXT = " + text);
-    });
-
     /* TODO - Mocking data is incorrect - text returns is:  Example Label 1,Example Label 1,
 
     expect(detailPage.attachedLabels().getText()).toContain(testLabelTitle1);
@@ -82,7 +73,7 @@ describe('Labels CRUD Tests', function () {
   });
 
   it('Verify removing existing label by unchecking label', function(){
-    detailPage = page.clickWorkItemTitle(page.firstWorkItem, firstitem.id);
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     detailPage.clickAddLabelButton();
     // Uncheck label by clicking on it again
     detailPage.selectLabelByTitle(defaultSelectedLableTitle);
@@ -93,7 +84,7 @@ describe('Labels CRUD Tests', function () {
   });
 
   it('Verify removing existing label by clicking x', function(){
-    detailPage = page.clickWorkItemTitle(page.firstWorkItem, firstitem.id);
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
 
     // Uncheck label by clicking on it again
 ////    detailPage.removeLabelByTitle(defaultSelectedLableTitle);
@@ -102,7 +93,7 @@ describe('Labels CRUD Tests', function () {
   });
 
   it('Verify adding new label', function(){
-    detailPage = page.clickWorkItemTitle(page.firstWorkItem, firstitem.id);
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     detailPage.clickAddLabelButton();
     detailPage.clickCreateLabelButton();
     detailPage.setLabelName(newLabelTitle);
@@ -121,7 +112,7 @@ describe('Labels CRUD Tests', function () {
   });
 
   it('Verify removing new label', function(){
-    detailPage = page.clickWorkItemTitle(page.firstWorkItem,firstitem.id);
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     detailPage.clickAddLabelButton();
     detailPage.clickCreateLabelButton();
     detailPage.setLabelName(newLabelTitle);
@@ -136,7 +127,7 @@ describe('Labels CRUD Tests', function () {
   });
 
   it('Verify added label appears on the list page', function(){
-    detailPage = page.clickWorkItemTitle(page.firstWorkItem,firstitem.id);
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     detailPage.clickAddLabelButton();
     detailPage.selectLabelByTitle(testLabelTitle1);
     detailPage.clickLabelClose();

--- a/runtime/src/tests/work-item/work-item-list/linkItem.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/linkItem.spec.js
@@ -25,96 +25,82 @@ describe('Link item ', function () {
 
   beforeEach(function () {
     testSupport.setBrowserMode('desktop');
-    page = new WorkItemListPage(true);  
-    // detailPage = new WorkItemDetailPage();  
-    testSupport.setTestSpace(page);  
+    page = new WorkItemListPage(true);
+    detailPage = new WorkItemDetailPage();
+    testSupport.setTestSpace(page);
   });
- /**Below commented code  works fine with the Chrome not with PhantomJS
-     * Issue : https://github.com/fabric8-ui/fabric8-planner/issues/319
-     */
-//  it('Create a link item planner to planner - Desktop', function () {
-//     var detailPage = page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
-//     expect(detailPage.commentDiv().isPresent()).toBe(true);
-//     expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);   
 
-//     browser.wait(until.elementToBeClickable(detailPage.linkItemHeaderCaret()), constants.WAIT, 'Link icon is not clickable');   
-//     detailPage.linkItemHeaderCaret().click();
-//     detailPage.clickCreateLinkButton(); 
-//     detailPage.clickLinkDropDown();
-//     detailPage.linkTypeDropDownListString("tests").click();
-   
-  //   detailPage.setSearchLinkItem("id0");
-  //   detailPage.clickOnLinkBind();
-  //   expect(detailPage.linkTitle()).toBe('Title Text 0');
-  //   expect(detailPage.linkState("0")).toBe('new');
-  //   expect(detailPage.linkclose("0").isPresent()).toBe(true);
-  //   expect(detailPage.linkTotalByTypes("0")).toBe("1");
-  //  });
-
-   it('Read a link item - Desktop', function () {
-    var detailPage = page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
-    expect(detailPage.commentDiv().isPresent()).toBe(true);
-    expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);   
-
-    browser.wait(until.elementToBeClickable(detailPage.linkItemHeaderCaret()), constants.WAIT, 'Link icon is not clickable');   
-    detailPage.linkItemHeaderCaret().click();
-     /**Below commented code  works fine with the Chrome not with PhantomJS
-     * Issue : https://github.com/fabric8-ui/fabric8-planner/issues/319
-     */
-    // expect(detailPage.linkTitle()).toBe('Title Text 1');
-    // expect(detailPage.linkItemTotalCount().getText()).toBe('1');
-    // expect(detailPage.linkState("0")).toBe('new');
-    // expect(detailPage.linkclose("0").isPresent()).toBe(true);
-   });
-   
-   it('Delete link and check if it exists in list or not - Desktop', function () {
-    var detailPage = page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
+  it('Create a link item planner to planner - Desktop', function () {
+    page.clickWorkItemTitle(page.workItemByTitle("Title Text 2"), "id2");
     expect(detailPage.commentDiv().isPresent()).toBe(true);
     expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);
 
-    browser.wait(until.elementToBeClickable(detailPage.linkItemHeaderCaret()), constants.WAIT, 'Link icon is not clickable');   
+    browser.wait(until.elementToBeClickable(detailPage.linkItemHeaderCaret()), constants.WAIT, 'Link icon is not clickable');
     detailPage.linkItemHeaderCaret().click();
-     /**Below commented code  works fine with the Chrome not with PhantomJS
-     * Issue : https://github.com/fabric8-ui/fabric8-planner/issues/319
-     */
-    // expect(detailPage.linkTitle()).toBe('Title Text 1');
-    // expect(detailPage.linkState("0")).toBe('new');
-    // expect(detailPage.linkclose("0").isPresent()).toBe(true);
-    // detailPage.linkclose("0").click();
-    // expect(detailPage.linkclose("0").isPresent()).toBe(false);
-    // expect(detailPage.createLinkButton.isPresent()).toBe(true);
+    detailPage.clickCreateLinkButton();
+    detailPage.clickLinkDropDown();
+    detailPage.linkTypeDropDownListString("tests").click();
+
+    detailPage.setSearchLinkItem("id0");
+    detailPage.clickOnLinkBind();
+    expect(detailPage.linkTitle()).toBe('Title Text 0');
+    expect(detailPage.linkclose("0").isPresent()).toBe(true);
+    expect(detailPage.linkTotalByTypes()).toBe("1");
    });
-   it('Update link child and check if it exists in list or not - Desktop', function () {
-    // var detailPage = page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
-    // detailPage.clickWorkItemDetailTitleClick();
-    // detailPage.setWorkItemDetailTitle("0", true);
-    // detailPage.workItemDetailTitle.sendKeys(protractor.Key.ENTER);
-    // detailPage.clickWorkItemDetailCloseButton();
-    // /**Below commented code  works fine with the Chrome not with PhantomJS
-    //  * Issue : https://github.com/fabric8-ui/fabric8-planner/issues/319
-    //  */
-    // // page.workItemByIndex("1").click();
-    // // expect(detailPage.commentDiv().isPresent()).toBe(true);
-    // // expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);   
-    // // detailPage.linkItemHeaderCaret().click();   
-    // // expect(detailPage.linkTitle()).toBe('Title Text 00');
-    // // expect(detailPage.linkState("0")).toBe('new');
-    // // expect(detailPage.linkclose("0").isPresent()).toBe(true);
-    // // detailPage.linkclose("0").click();
-    // // expect(detailPage.linkclose("0").isPresent()).toBe(false);
-    // // expect(detailPage.createLinkButton.isPresent()).toBe(true);
-   });
-   it('Check the elements of link item div are visible - Desktop', function () {
-    var detailPage = page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
+
+  it('Read a link item - Desktop', function () {
+    page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
     expect(detailPage.commentDiv().isPresent()).toBe(true);
-    expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);  
+    expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);
 
-    browser.wait(until.elementToBeClickable(detailPage.linkItemHeaderCaret()), constants.WAIT, 'Link icon is not clickable');   
+    browser.wait(until.elementToBeClickable(detailPage.linkItemHeaderCaret()), constants.WAIT, 'Link icon is not clickable');
     detailPage.linkItemHeaderCaret().click();
-    // expect(detailPage.linkItemTitle()).toBe("This item, Title Text 0");
-    // expect(detailPage.checkLinkDropDown.isPresent()).toBe(true);
+    expect(detailPage.linkTitle()).toBe('Title Text 1');
+    expect(detailPage.linkItemTotalCount().getText()).toBe('1');
+    expect(detailPage.linkclose("0").isPresent()).toBe(true);
    });
 
+  it('Delete link and check if it exists in list or not - Desktop', function () {
+    page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
+    expect(detailPage.commentDiv().isPresent()).toBe(true);
+    expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);
+
+    browser.wait(until.elementToBeClickable(detailPage.linkItemHeaderCaret()), constants.WAIT, 'Link icon is not clickable');
+    detailPage.linkItemHeaderCaret().click();
+    expect(detailPage.linkTitle()).toBe('Title Text 1');
+    expect(detailPage.linkclose("0").isPresent()).toBe(true);
+    detailPage.linkclose("0").click();
+    expect(detailPage.linkclose("0").isPresent()).toBe(false);
+    expect(detailPage.createLinkButton.isPresent()).toBe(true);
+   });
+
+  it('Update link child and check if it exists in list or not - Desktop', function () {
+    page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
+    detailPage.clickWorkItemDetailTitleClick();
+    detailPage.setWorkItemDetailTitle("0", true); // Update title
+    detailPage.clickWorkItemTitleSaveIcon();
+    detailPage.clickWorkItemDetailCloseButton();
+    page.clickWorkItemTitle(page.workItemByTitle("Title Text 1"), "id1");
+    expect(detailPage.commentDiv().isPresent()).toBe(true);
+    expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);
+    detailPage.linkItemHeaderCaret().click();
+    expect(detailPage.linkTitle()).toBe('Title Text 00'); // Verify new title
+    expect(detailPage.linkclose("0").isPresent()).toBe(true);
+    detailPage.linkclose("0").click();
+    expect(detailPage.linkclose("0").isPresent()).toBe(false);
+    expect(detailPage.createLinkButton.isPresent()).toBe(true);
+   });
+
+  it('Check the elements of link item div are visible - Desktop', function () {
+    page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
+    expect(detailPage.commentDiv().isPresent()).toBe(true);
+    expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);
+
+    browser.wait(until.elementToBeClickable(detailPage.linkItemHeaderCaret()), constants.WAIT, 'Link icon is not clickable');
+    detailPage.linkItemHeaderCaret().click();
+    expect(detailPage.linkItemTitle()).toBe("This item, Title Text 0");
+    expect(detailPage.checkLinkDropDown.isPresent()).toBe(true);
+   });
 
 });
 

--- a/runtime/src/tests/work-item/work-item-list/linkItem.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/linkItem.spec.js
@@ -16,8 +16,7 @@
 
 var WorkItemListPage = require('./page-objects/work-item-list.page'),
   testSupport = require('./testSupport'),
-  constants = require('./constants'),
-  WorkItemDetailPage = require('./page-objects/work-item-detail.page');
+  constants = require('./constants');
 
 describe('Link item ', function () {
   var page, items, browserMode;
@@ -26,12 +25,11 @@ describe('Link item ', function () {
   beforeEach(function () {
     testSupport.setBrowserMode('desktop');
     page = new WorkItemListPage(true);
-    detailPage = new WorkItemDetailPage();
     testSupport.setTestSpace(page);
   });
 
   it('Create a link item planner to planner - Desktop', function () {
-    page.clickWorkItemTitle(page.workItemByTitle("Title Text 2"), "id2");
+    var detailPage = page.clickWorkItemTitle("Title Text 2");
     expect(detailPage.commentDiv().isPresent()).toBe(true);
     expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);
 
@@ -49,7 +47,7 @@ describe('Link item ', function () {
    });
 
   it('Read a link item - Desktop', function () {
-    page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
+    var detailPage = page.clickWorkItemTitle("Title Text 0");
     expect(detailPage.commentDiv().isPresent()).toBe(true);
     expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);
 
@@ -61,7 +59,7 @@ describe('Link item ', function () {
    });
 
   it('Delete link and check if it exists in list or not - Desktop', function () {
-    page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
+    var detailPage = page.clickWorkItemTitle("Title Text 0");
     expect(detailPage.commentDiv().isPresent()).toBe(true);
     expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);
 
@@ -75,12 +73,12 @@ describe('Link item ', function () {
    });
 
   it('Update link child and check if it exists in list or not - Desktop', function () {
-    page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
+    var detailPage = page.clickWorkItemTitle("Title Text 0");
     detailPage.clickWorkItemDetailTitleClick();
     detailPage.setWorkItemDetailTitle("0", true); // Update title
     detailPage.clickWorkItemTitleSaveIcon();
     detailPage.clickWorkItemDetailCloseButton();
-    page.clickWorkItemTitle(page.workItemByTitle("Title Text 1"), "id1");
+    var detailPage = page.clickWorkItemTitle("Title Text 1");
     expect(detailPage.commentDiv().isPresent()).toBe(true);
     expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);
     detailPage.linkItemHeaderCaret().click();
@@ -92,7 +90,7 @@ describe('Link item ', function () {
    });
 
   it('Check the elements of link item div are visible - Desktop', function () {
-    page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
+    var detailPage = page.clickWorkItemTitle("Title Text 0");
     expect(detailPage.commentDiv().isPresent()).toBe(true);
     expect(detailPage.linkItemHeaderCaret().isPresent()).toBe(true);
 

--- a/runtime/src/tests/work-item/work-item-list/page-objects/work-item-detail.page.js
+++ b/runtime/src/tests/work-item/work-item-list/page-objects/work-item-detail.page.js
@@ -643,16 +643,13 @@ testSupport.clickElement(this.workItemDescriptionCancelIcon, "workItemDescriptio
     return element(by.id("bind-link")).click();
   }
   linkTitle (){
-    return element(by.css(".link-title")).getText();
-  }
-  linkState (index){
-    return element(by.id("linkSWIstate_" + index)).getText();
+    return element(by.css(".f8-link__list-item-title")).getText();
   }
   linkclose (index){
     return element(by.id("closeLink_" + index));
   }
-  linkTotalByTypes (index){
-    return element(by.id("linktotal_" + index)).getText();
+  linkTotalByTypes (){
+    return element(by.id("wi-link-total")).getText();
   }
   linkItemTitle (){
     return element(by.id("link_item_title")).getText();

--- a/runtime/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
+++ b/runtime/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
@@ -261,7 +261,7 @@ class WorkItemListPage {
   /* xpath = //alm-work-item-list-entry[.//text()[contains(.,'Some Title 6')]]   */
   workItemByTitle (titleString) {
     // return element(by.xpath("//alm-work-item-list-entry[.//text()[contains(.,'" + titleString + "')]]"));
-    return element(by.xpath("//tree-node[.//text()[contains(.,'" + titleString + "')]]"));
+    return element(by.xpath("//tree-node[.//text()='" + titleString + "']"));
   }
 
   get firstWorkItem () {

--- a/runtime/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
+++ b/runtime/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
@@ -277,13 +277,13 @@ class WorkItemListPage {
     return workItemElement.element(by.css(".f8-wi__list-title")).element(by.css("p")).getText();
   }
 
-  clickWorkItemTitle (workItemElement, idText) {
-    workItemElement.element(by.css(".f8-wi__list-title")).element(by.css("p")).click();
-    var theDetailPage = new WorkItemDetailPage (idText);
-    var until = protractor.ExpectedConditions;
-    //browser.wait(until.presenceOf(theDetailPage.workItemDetailPageTitle), constants.WAIT, 'Detail page title taking too long to appear in the DOM');
-    browser.wait(testSupport.waitForText(theDetailPage.clickWorkItemDetailTitle), constants.WAIT, "Title text is still not present");
-    return theDetailPage;
+  clickWorkItemTitle (title) {
+    return this.clickWorkItem(this.workItemByTitle(title));
+  }
+
+  clickWorkItem(workItemElement) {
+    workItemElement.element(by.css(".f8-wi__list-description")).element(by.css("p")).click()
+    return new WorkItemDetailPage();
   }
 
   /* Description element relative to a workitem */

--- a/runtime/src/tests/work-item/work-item-list/smokeTest.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/smokeTest.spec.js
@@ -46,7 +46,7 @@ describe('Work item list', function () {
     page.typeQuickAddWorkItemTitle(WORK_ITEM_TITLE);
     page.clickQuickAddSave().then(function() {
       page.workItemViewId(page.workItemByTitle(WORK_ITEM_TITLE)).getText().then(function (text) {
-        var detailPage = page.clickWorkItemTitle(page.workItemByTitle(WORK_ITEM_TITLE), text);
+        var detailPage = page.clickWorkItemTitle(WORK_ITEM_TITLE);
         browser.wait(until.elementToBeClickable(detailPage.workItemDetailAssigneeIcon), constants.WAIT, 'Failed to find Assignee Icon');
         detailPage.clickworkItemDetailAssigneeIcon();
         detailPage.setWorkItemDetailAssigneeSearch(EXAMPLE_USER_1, false);
@@ -71,7 +71,7 @@ describe('Work item list', function () {
       /* Fill in/update the new work item's title and details field */
       expect(page.workItemTitle(page.workItemByTitle(WORK_ITEM_TITLE))).toBe(WORK_ITEM_TITLE);
       page.workItemViewId(page.workItemByTitle(WORK_ITEM_TITLE)).getText().then(function (text) {
-        var detailPage = page.clickWorkItemTitle(page.workItemByTitle(WORK_ITEM_TITLE), text);
+        var detailPage = page.clickWorkItemTitle(WORK_ITEM_TITLE);
         browser.wait(until.elementToBeClickable(detailPage.workItemDetailAssigneeIcon), constants.WAIT, 'Failed to find Assignee Icon');
         detailPage.clickWorkItemDetailTitleClick();
         detailPage.setWorkItemDetailTitle (WORK_ITEM_UPDATED_TITLE, false);
@@ -112,7 +112,7 @@ describe('Work item list', function () {
   /* Create workitem - verify user and icon */
   // it('Edit and check WorkItem , creatorname and image is reflected', function () {
   //   page.clickDetailedDialogButton();
-  //   var detailPage = page.clickDetailedIcon("userstory");
+  //   page.clickDetailedIcon("userstory");
   //   browser.wait(until.elementToBeClickable(detailPage.workItemDetailAssigneeIcon), constants.WAIT, 'Failed to find workItem');
 
   //   detailPage.setWorkItemDetailTitle (WORK_ITEM_TITLE, false);
@@ -137,7 +137,7 @@ describe('Work item list', function () {
   // });
 
 it('check date showing up correctly - Desktop', function () {
-    var detailPage = page.clickWorkItemTitle(page.firstWorkItem, "Title Text 0");
+    var detailPage = page.clickWorkItemTitle(MOCK_WORKITEM_TITLE_0);
     browser.wait(until.elementToBeClickable(page.firstWorkItem), constants.WAIT, 'Failed to find workItem');
     expect(detailPage.getCreatedtime()).toBe('a few seconds ago');
     browser.wait(until.elementToBeClickable(detailPage.workItemDetailCloseButton), constants.WAIT, 'Failed to find close workItem detail page');
@@ -145,7 +145,7 @@ it('check date showing up correctly - Desktop', function () {
  });
 
   it('Updating area to a WI -desktop ', function() {
-      var detailPage = page.clickWorkItemTitle(page.firstWorkItem, WORKITEM_0_ID);
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       browser.wait(until.elementToBeClickable(detailPage.areaLabel), constants.WAIT, 'Failed to find areaLabel');
       detailPage.clickAreaSelect();
       detailPage.clickAreas(WORKITEM_0_ID);
@@ -163,14 +163,14 @@ it('check date showing up correctly - Desktop', function () {
      });
 
    it('Re-Associate Workitem from detail page', function() {
-      var detailPage = page.clickWorkItemTitle(page.firstWorkItem, "id0");
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       detailPage.IterationOndetailPage().click();
       detailPage.associateIterationById("id1");
       detailPage.saveIteration();
       expect(detailPage.getAssociatedIteration()).toBe("/Root Iteration/Iteration 1");
       detailPage.clickWorkItemDetailCloseButton();
       // Re - assocaite
-      page.clickWorkItemTitle(page.firstWorkItem, "id0");
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
       detailPage.IterationOndetailPage().click();
       detailPage.associateIterationById("id0");
       detailPage.saveIteration();
@@ -179,13 +179,13 @@ it('check date showing up correctly - Desktop', function () {
     });
 
   it('Try clicking on start coding it should redirect - Desktop', function () {
-    var detailPage = page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
+    var detailPage = page.clickWorkItemTitle(MOCK_WORKITEM_TITLE_0);
     expect(detailPage.startCodingElement.isPresent()).toBe(true);
     detailPage.clickStartCoding();
    });
 
   it('Edit comment and cancel - Desktop ', function() {
-    var detailPage = page.clickWorkItemTitle(page.firstWorkItem, "id0");
+    var detailPage = page.clickWorkItem(page.firstWorkItem);
     detailPage.scrollToBottom()
       .then(function() {
         detailPage.commentEdit('0').click();

--- a/runtime/src/tests/work-item/work-item-list/startcoding.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/startcoding.spec.js
@@ -29,7 +29,7 @@ var waitTime = 30000;
     testSupport.setTestSpace(page);
   });
  it('Verify start coding is visible when code base is present - Desktop', function () {
-    var detailPage = page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
+    var detailPage = page.clickWorkItemTitle("Title Text 0");
     browser.wait(until.textToBePresentInElement((detailPage.startCodingElement.getText()), 'Start Coding'), waitTime);
     expect(detailPage.startCodingElement.isPresent()).toBe(true);
     expect(detailPage.startCodingElement.getText()).toBe('Start Coding');
@@ -41,20 +41,20 @@ var waitTime = 30000;
     page.typeQuickAddWorkItemTitle(workItemTitle);
     page.clickQuickAddSave();
     page.workItemViewId(page.workItemByTitle(workItemTitle)).getText().then(function (text) {
-        var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text); 
+        var detailPage = page.clickWorkItem(page.firstWorkItem); 
           expect((detailPage.startCodingElement.isPresent().not));
           expect((detailPage.startCodingLabel().isPresent().not));
     }); 
    });
  it('Try clicking on start coding it should redirect - Desktop', function () {
-    var detailPage = page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
+    var detailPage = page.clickWorkItemTitle("Title Text 0");
     // expect(detailPage.startCodingElement.isPresent()).toBe(true);
     expect(detailPage.startCodingElement.getAttribute('href')).toEqual('http://mock.service/codebase');
     detailPage.clickStartCoding();
    });
 
  it('Verify start coding label is visible when code base is present - Desktop', function () {
-    var detailPage = page.clickWorkItemTitle(page.workItemByTitle("Title Text 0"), "id0");
+    var detailPage = page.clickWorkItemTitle("Title Text 0");
     browser.wait(until.textToBePresentInElement((detailPage.startCodingElement.getText()), 'Start Coding'), waitTime);
     expect(detailPage.startCodingLabel().isPresent()).toBe(true);
     expect(detailPage.startCodingLabel().getText()).toBe('Code');

--- a/runtime/src/tests/work-item/work-item-list/testHelpers.js
+++ b/runtime/src/tests/work-item/work-item-list/testHelpers.js
@@ -118,7 +118,7 @@ module.exports = {
         page.workItemViewId(theWorkItem).getText().then(function (text) { 
 
             /* Access the workitem's detailpage */
-            var detailPage = page.clickWorkItemTitle(theWorkItem, text);
+            var detailPage = page.clickWorkItemTitle(theWorkItem);
 
             /* Assign the workitem */
             browser.wait(until.elementToBeClickable(detailPage.workItemDetailAssigneeIcon), constants.WAIT, 'Failed to find Assignee Icon');   
@@ -153,7 +153,7 @@ module.exports = {
         page.workItemViewId(theWorkItem).getText().then(function (text) { 
 
             /* Access the workitem's detailpage */
-            var detailPage = page.clickWorkItemTitle(theWorkItem, text);
+            var detailPage = page.clickWorkItemTitle(theWorkItem);
             browser.wait(until.elementToBeClickable(detailPage.details_assigned_user()), constants.WAIT, 'Failed to find Assignee Icon');   
  
             expect(detailPage.details_assigned_user().getText()).toContain(assigneeName);
@@ -201,7 +201,7 @@ module.exports = {
         //console.log (theText);
 
         page.workItemViewId(page.workItemByTitle(oldTitleText)).getText().then(function (text) { 
-            var detailPage = page.clickWorkItemTitle(page.workItemByTitle(oldTitleText), text);
+            var detailPage = page.clickWorkItemTitle(oldTitleText);
 
             detailPage.clickWorkItemDetailTitleClick();
 
@@ -244,7 +244,7 @@ module.exports = {
         page.workItemViewId(theWorkItem).getText().then(function (text) { 
 
             /* Access the workitem's detailpage */
-            var detailPage = page.clickWorkItemTitle(theWorkItem, text);
+            var detailPage = page.clickWorkItem(theWorkItem);
             browser.wait(until.elementToBeClickable(detailPage.details_assigned_user()), constants.WAIT, 'Failed to find Assignee Icon');     
 
 //            expect(detailPage.clickWorkItemDetailTitle.getText()).toContain(workitemTitle);
@@ -271,7 +271,7 @@ module.exports = {
         //console.log (theText);
 
         page.workItemViewId(page.workItemByTitle(titleText)).getText().then(function (text) { 
-            var detailPage = page.clickWorkItemTitle(page.workItemByTitle(titleText), text);
+            var detailPage = page.clickWorkItemTitle(titleText);
 
             detailPage.clickWorkItemDetailDescription();
 
@@ -314,7 +314,7 @@ module.exports = {
         page.workItemViewId(theWorkItem).getText().then(function (text) { 
 
             /* Access the workitem's detailpage */
-            var detailPage = page.clickWorkItemTitle(theWorkItem, text);
+            var detailPage = page.clickWorkItemTitle(theWorkItem);
             browser.wait(until.elementToBeClickable(detailPage.details_assigned_user()), constants.WAIT, 'Failed to find Assignee Icon');     
 
             //expect(detailPage.workItemDetailDescription.getText()).toContain(workitemDesc);

--- a/runtime/src/tests/work-item/work-item-list/work-item-dynamic-fields.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/work-item-dynamic-fields.spec.js
@@ -38,7 +38,7 @@ describe('Work item list', function () {
   it('Verify new dynamic fields in a workitem', function () {
 
     page.workItemViewId(page.firstWorkItem).getText().then(function (text) { 
-      var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);   
+      var detailPage = page.clickWorkItem(page.firstWorkItem);
 
       detailPage.clickStepsToReproduceText();
       detailPage.setstepsToReproduceText('THIS IS A TEST');

--- a/runtime/src/tests/work-item/work-item-list/work-item-list.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/work-item-list.spec.js
@@ -57,7 +57,7 @@ describe('Work item list', function () {
 
   it('should contain right mock data on detail page - desktop.', function() { 
       page.workItemViewId(page.firstWorkItem).getText().then(function (text) { 
-        var detailPage = page.clickWorkItemTitle(page.firstWorkItem, text);
+        var detailPage = page.clickWorkItem(page.firstWorkItem);
         browser.wait(until.elementToBeClickable(detailPage.workItemDetailAssigneeIcon), constants.WAIT, 'Failed to find Assignee Icon');   
         
         /* TODO - text in title/desc fields once updated is not visible in DOM - have to find a diff way to get the text */

--- a/src/app/components/work-item-link/work-item-link.component.html
+++ b/src/app/components/work-item-link/work-item-link.component.html
@@ -83,7 +83,7 @@
                     <a (click)="onSelectRelation(linkType)">{{linkType.name}}</a>
                   </li>
                 </ul>
-                <span class="input-group-addon dropdown-toggle pointer"
+                <span class="input-group-addon dropdown-toggle pointer" id="wi-link-type"
                   dropdownToggle>
                   <span class="caret"></span>
                 </span>


### PR DESCRIPTION
This PR updates the `clickWorkitemTitle` method and depends on https://github.com/fabric8-ui/fabric8-planner/pull/2306.

All the tests (which are modified in this PR) passed when I ran the PR locally.