### PR TITLE
fix(iteration panel): display close option in kebab menu only for active iterations

### DIFF
--- a/src/app/components/iterations-panel/iterations-panel.component.html
+++ b/src/app/components/iterations-panel/iterations-panel.component.html
@@ -144,8 +144,36 @@
         </ng-template>
         <ng-template #actionTemplate let-node="node" let-index="index">
           <pfng-action class="list-pf-actions"
-            [config]="actionConfig"
-            (onActionSelect)="handleAction($event, node)">
+            [template]="kebabAction">
+            <ng-template #kebabAction>
+              <div *ngIf="loggedIn"
+                class="dropdown-kebab-pf pull-right dropdown" dropdown>
+                <button class="btn btn-link dropdown-toggle" type="button" dropdownToggle>
+                  <span class="fa fa-ellipsis-v"></span>
+                </button>
+                  <ul class="dropdown-menu-right dropdown-menu"
+                  *dropdownMenu>
+                  <li>
+                    <a class="pointer"
+                      (click)="onEdit(node.data)">
+                      Edit
+                    </a>
+                  </li>
+                  <li *ngIf="node.data.attributes.active_status">
+                    <a class="pointer"
+                      (click)="onClose(node.data)">
+                        Close
+                    </a>
+                  </li>
+                  <li>
+                    <a class="pointer"
+                      (click)="onCreateChild(node.data)">
+                        Create child
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </ng-template>
           </pfng-action>
         </ng-template>
       </pfng-tree-list>

--- a/src/app/components/iterations-panel/iterations-panel.component.ts
+++ b/src/app/components/iterations-panel/iterations-panel.component.ts
@@ -20,7 +20,6 @@ import { WorkItem } from '../../models/work-item';
 import { FabPlannerIterationModalComponent } from '../iterations-modal/iterations-modal.component';
 import {
   Action,
-  ActionConfig,
   EmptyStateConfig,
   ListBase,
   ListEvent,
@@ -58,7 +57,6 @@ export class IterationComponent implements OnInit, OnDestroy, OnChanges {
   masterIterations;
   treeIterations;
   activeIterations:IterationModel[] = [];
-  actionConfig: ActionConfig;
   emptyStateConfig: EmptyStateConfig;
   treeListConfig: TreeListConfig;
 
@@ -137,26 +135,6 @@ export class IterationComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   setTreeConfigs() {
-    this.actionConfig = {
-      primaryActions: [],
-      moreActions: [{
-        id: 'edit',
-        title: 'Edit',
-        tooltip: 'Edit this iteration'
-      }, {
-        id: 'close',
-        title: 'Close',
-        tooltip: 'Close this iteration'
-      },
-      {
-        id: 'createChild',
-        title: 'Create Child',
-        tooltip: 'Create a child under this iteration',
-      }],
-      moreActionsDisabled: !this.loggedIn,
-      moreActionsVisible: this.loggedIn
-    } as ActionConfig;
-
     this.emptyStateConfig = {
       iconStyleClass: '',
       title: 'No Iterations Available',
@@ -487,20 +465,6 @@ export class IterationComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   //Patternfly-ng's tree list related functions
-  handleAction($event: Action, item: any): void {
-    switch($event.id) {
-      case 'edit':
-        this.onEdit(item.data);
-      break;
-      case 'createChild':
-        this.onCreateChild(item.data);
-      break;
-      case 'close':
-        this.onClose(item.data);
-      break;
-    }
-  }
-
   handleClick($event: Action, item: any) {
   }
 


### PR DESCRIPTION
Display Close option in the iteration's kebab menu, only if the iteration is an active one. Fixes [OSIO-1615](https://openshift.io/openshiftio/openshiftio/plan/detail/1615)

![a](https://user-images.githubusercontent.com/9278015/32164180-afcf5a82-bd84-11e7-8540-5fca4c1565a9.gif)
