### PR TITLE
Resolves: Parent information for a work item disappears

### DIFF
--- a/src/app/components/planner-list/planner-list.component.ts
+++ b/src/app/components/planner-list/planner-list.component.ts
@@ -712,6 +712,8 @@ export class PlannerListComponent implements OnInit, AfterViewInit, DoCheck, OnD
       this.workItemService.editWIObservable.subscribe(updatedItem => {
         let index = this.workItems.findIndex((item) => item.id === updatedItem.id);
         if(this.filterService.doesMatchCurrentFilter(updatedItem)){
+          updatedItem.hasChildren = updatedItem.relationships.children.meta.hasChildren;
+          updatedItem.relationships['parent'] = this.workItems[index].relationships.parent;
           if (index > -1) {
             this.workItems[index] = updatedItem;
           } else {


### PR DESCRIPTION
Issue:
- Whenever a new label is applied to a workitem it's parent information disappears
![b](https://user-images.githubusercontent.com/9278015/32606827-ca20ac60-c57c-11e7-9ca3-357c1d11d14b.gif)

- on Workitem update workitems child information disappears

This PR resolves these two issues
