### PR TITLE
fix(iterations): Display all work item types for an iteration without duplicates. 

### DIFF
--- a/src/app/components/iteration-list-entry/iteration-list-entry.component.ts
+++ b/src/app/components/iteration-list-entry/iteration-list-entry.component.ts
@@ -83,17 +83,18 @@ export class IterationListEntryComponent implements OnInit, OnDestroy {
     //Join type and space query
     const first_join = this.filterService.queryJoiner({}, this.filterService.and_notation, it_query );
 
+    //For better usability, show all work items under an iteration
     //Iterations should only show allowed work item types
-    const wi_key = 'workitemtype';
-    const wi_compare = this.filterService.in_notation;
-    const wi_value = this.collection;
+    // const wi_key = 'workitemtype';
+    // const wi_compare = this.filterService.in_notation;
+    // const wi_value = this.collection;
 
     //Query for type
-    const type_query = this.filterService.queryBuilder(wi_key, wi_compare, wi_value);
-    const second_join = this.filterService.queryJoiner(first_join, this.filterService.and_notation, type_query );
+    //const type_query = this.filterService.queryBuilder(wi_key, wi_compare, wi_value);
+    //const second_join = this.filterService.queryJoiner(first_join, this.filterService.and_notation, type_query );
     //const second_join = this.filterService.queryJoiner(first_join, this.filterService.and_notation, type_query );
     //second_join gives json object
-    return this.filterService.jsonToQuery(second_join);
+    return this.filterService.jsonToQuery(first_join);
     //reverse function jsonToQuery(second_join);
     //return '';
   }

--- a/src/app/components/planner-list/planner-list.component.ts
+++ b/src/app/components/planner-list/planner-list.component.ts
@@ -355,8 +355,10 @@ export class PlannerListComponent implements OnInit, AfterViewInit, DoCheck, OnD
     //if initialGroup is undefined, the page has been refreshed - find  group context based on URL
     if ( this.route.snapshot.queryParams['q'] ) {
       let wits = this.route.snapshot.queryParams['q'].split('workitemtype:')
-      let collection = wits[1].replace(')','').split(',');
-      this.groupTypesService.findGroupConext(collection);
+      if(wits.length > 1) {
+        let collection = wits[1].replace(')','').split(',');
+        this.groupTypesService.findGroupConext(collection);
+      }
     }
     if(this.initialGroup === undefined)
       this.initialGroup = this.groupTypesService.getCurrentGroupType();

--- a/src/app/components/planner-list/planner-list.component.ts
+++ b/src/app/components/planner-list/planner-list.component.ts
@@ -465,9 +465,20 @@ export class PlannerListComponent implements OnInit, AfterViewInit, DoCheck, OnD
       console.log('Performance :: Fetching the initial list - '  + (t2 - t1) + ' milliseconds.');
       this.logger.log('Got work item list.');
       this.logger.log(workItemResp.workItems);
-      const workItems = workItemResp.workItems;
+      const workItemsAll = workItemResp.workItems;
       this.nextLink = workItemResp.nextLink;
       this.included = workItemResp.included;
+      //Remove work item duplicates - a child work item
+      //should not appear part of the root response
+      const workItems = workItemsAll.filter( wi => {
+        if( wi.relationships.parent.data != undefined ) {
+          //take the parent ID and loop thorough the work items
+          if (workItemsAll.findIndex(item => item.id === wi.relationships.parent.data.id) === -1)
+            return wi;
+        } else {
+          return wi;
+        }
+      });
       this.workItems = this.workItemService.resolveWorkItems(
         workItems,
         this.iterations,

--- a/src/app/components/planner-list/planner-list.component.ts
+++ b/src/app/components/planner-list/planner-list.component.ts
@@ -466,19 +466,22 @@ export class PlannerListComponent implements OnInit, AfterViewInit, DoCheck, OnD
       this.logger.log('Got work item list.');
       this.logger.log(workItemResp.workItems);
       const workItemsAll = workItemResp.workItems;
+      const workItems = workItemsAll;
       this.nextLink = workItemResp.nextLink;
       this.included = workItemResp.included;
       //Remove work item duplicates - a child work item
-      //should not appear part of the root response
-      const workItems = workItemsAll.filter( wi => {
-        if( wi.relationships.parent.data != undefined ) {
-          //take the parent ID and loop thorough the work items
-          if (workItemsAll.findIndex(item => item.id === wi.relationships.parent.data.id) === -1)
+      //should not appear part of the root response only for iterations
+      if (this.groupTypesService.groupName === 'execution') {
+        const workItems = workItemsAll.filter( wi => {
+          if( wi.relationships.parent.data != undefined ) {
+            //take the parent ID and loop thorough the work items
+            if (workItemsAll.findIndex(item => item.id === wi.relationships.parent.data.id) === -1)
+              return wi;
+          } else {
             return wi;
-        } else {
-          return wi;
-        }
-      });
+          }
+        });
+      }
       this.workItems = this.workItemService.resolveWorkItems(
         workItems,
         this.iterations,

--- a/src/app/components/planner-list/planner-list.component.ts
+++ b/src/app/components/planner-list/planner-list.component.ts
@@ -466,24 +466,28 @@ export class PlannerListComponent implements OnInit, AfterViewInit, DoCheck, OnD
       this.logger.log('Got work item list.');
       this.logger.log(workItemResp.workItems);
       const workItemsAll = workItemResp.workItems;
-      const workItems = workItemsAll;
+      let tempWIs = []
       this.nextLink = workItemResp.nextLink;
       this.included = workItemResp.included;
       //Remove work item duplicates - a child work item
       //should not appear part of the root response only for iterations
       if (this.groupTypesService.groupName === 'execution') {
-        const workItems = workItemsAll.filter( wi => {
+        tempWIs = workItemsAll.filter( wi => {
           if( wi.relationships.parent.data != undefined ) {
             //take the parent ID and loop thorough the work items
-            if (workItemsAll.findIndex(item => item.id === wi.relationships.parent.data.id) === -1)
+            let i = workItemsAll.findIndex(item => item.id === wi.relationships.parent.data.id);
+            if (i === -1) {
               return wi;
+            }
           } else {
             return wi;
           }
         });
+      } else {
+        tempWIs = workItemsAll;
       }
       this.workItems = this.workItemService.resolveWorkItems(
-        workItems,
+        tempWIs,
         this.iterations,
         [], // We don't want to static resolve user at this point
         this.workItemTypes,


### PR DESCRIPTION
Fixes 
1. [OSIO 1698](https://openshift.io/openshiftio/openshiftio/plan/detail/1698) - Remove duplicate child work items returned as part of root response
2. [OSIO 1699](https://openshift.io/openshiftio/openshiftio/plan/detail/1699) - Remove work item type filtering for iterations

Change in behaviour introduced by this PR
1. All work item types can now be seen under an iteration. We don't have to use iteration labels.
2. Duplicate responses have been removed from the tree. A child appeared at the root level and the expanded table. The child appears only under the parent.