### PR TITLE
feat(deploy): run integrated planner stack on minishift

### DIFF
--- a/devops/kedge/auth.yml
+++ b/devops/kedge/auth.yml
@@ -1,0 +1,19 @@
+name: auth
+controller: DeploymentConfig
+containers:
+- image: fabric8/fabric8-auth:latest
+  env:
+  - name: AUTH_WIT_URL
+    value: "[[ AUTH_WIT_URL ]]"
+  - name: AUTH_DEVELOPER_MODE_ENABLED
+    value: "true"
+  - name: AUTH_POSTGRES_HOST
+    value: "db-auth"
+  - name: AUTH_POSTGRES_PORT
+    value: "5432"
+services:
+- name: auth
+  type: NodePort
+  ports:
+  - port: 8089
+    nodePort: 31000

--- a/devops/kedge/db-auth.yml
+++ b/devops/kedge/db-auth.yml
@@ -1,0 +1,11 @@
+name: db-auth
+controller: DeploymentConfig
+containers:
+- image: registry.centos.org/postgresql/postgresql:9.6
+  env:
+  - name: POSTGRESQL_ADMIN_PASSWORD
+    value: mysecretpassword
+services:
+- name: db-auth
+  ports:
+  - port: 5432

--- a/devops/kedge/db.yml
+++ b/devops/kedge/db.yml
@@ -1,0 +1,13 @@
+name: db
+controller: DeploymentConfig
+containers:
+- image: registry.centos.org/postgresql/postgresql:9.6
+  env:
+  - name: POSTGRESQL_ADMIN_PASSWORD
+    value: mysecretpassword
+services:
+- name: db
+  type: NodePort
+  ports:
+  - port: 5432
+    nodePort: 32000

--- a/devops/kedge/planner.yml
+++ b/devops/kedge/planner.yml
@@ -1,0 +1,13 @@
+name: planner
+controller: DeploymentConfig
+containers:
+- image: fabric8/fabric8-ui:[[F8UI_IMAGE_TAG]]
+  env:
+  - name: PROXY_PASS_URL
+    value: "https://api.free-int.openshift.com:443"
+services:
+- name: planner
+  type: NodePort
+  ports:
+    - port: 8080
+      nodePort: 32123

--- a/devops/kedge/wit.yml
+++ b/devops/kedge/wit.yml
@@ -1,0 +1,17 @@
+name: wit
+controller: DeploymentConfig
+containers:
+- image: fabric8/fabric8-wit:latest
+  env:
+  - name: F8_AUTH_URL
+    value: "[[ F8_AUTH_URL ]]"
+  - name: F8_DEVELOPER_MODE_ENABLED
+    value: "true"
+  - name: F8_POSTGRES_HOST
+    value: "db"
+services:
+- name: wit
+  type: NodePort
+  ports:
+    - port: 8080
+      nodePort: 30000


### PR DESCRIPTION
Use the following steps to review the PR (bootstrapping script coming up next):

**You need to have `Kedge` & `Minishift` set up before proceeding.**

```bash
# Change to kedge directory, or replace yml file paths accordingly in following commands 
cd devops/kedge

# Deploy the database services as is
kedge apply -f kedge/db.yml -f kedge/db-auth.yml

# Start the auth and wit services with environment variables
AUTH_WIT_URL=http://minishift.local:8080 kedge apply -f kedge/auth.yml
F8_AUTH_URL=http://minishift.local:31000 kedge apply -f kedge/wit.yml

# Start the planner service with the image tag mentioned
F8UI_IMAGE_TAG=<tag-from-docker-hub> kedge apply -f kedge/planner.yml
```

You need to have `<tag-from-docker-hub>` copied from [docker hub](https://hub.docker.com/r/fabric8/fabric8-ui/tags/) and replace the value in script.

You also need to add hosts file entry to recognize the value of `$ minishift ip` as `minishift.local` domain name in order for auth redirection to work properly.

Monitor the deployments from OpenShift dashboard, and create routes for `planner` if you wish.

In order to clean up after you're done, you can minutely manage/remove pods and deployments as you wish (consult oc and minishift docs for details), or you can clean up the whole project by taking the following steps:

```bash
oc project # outputs the active project name, make a note of that for next step
oc delete project <project-name> # removes the project with everything in it :)
```