### PR TITLE
fix(work-item-links): Display toast notification to indicate that a work item can have a single parent.

### DIFF
--- a/src/app/components/work-item-link/work-item-link.component.ts
+++ b/src/app/components/work-item-link/work-item-link.component.ts
@@ -4,7 +4,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { Http } from '@angular/http';
 import { cloneDeep, trimEnd } from 'lodash';
 
-import { Broadcaster } from 'ngx-base';
+import { Broadcaster, Notification, NotificationType, Notifications } from 'ngx-base';
 
 import { Link } from '../../models/link';
 import { LinkDict } from '../../models/work-item';
@@ -48,6 +48,7 @@ export class WorkItemLinkComponent implements OnInit, OnChanges, DoCheck, OnDest
     private route: ActivatedRoute,
     private broadcaster: Broadcaster,
     private eventService: EventService,
+    private notifications: Notifications,
     http: Http
   ){}
 
@@ -153,7 +154,18 @@ export class WorkItemLinkComponent implements OnInit, OnChanges, DoCheck, OnDest
         this.resetSearchData();
         this.eventService.workItemListReloadOnLink.next(true);
       },
-      (error: any) => console.log(error));
+      (error: any) => {
+        if((error._body).indexOf('single parent in tree topology') >= 0) {
+          try {
+              this.notifications.message({
+              message: 'Work item can only have a single parent.',
+              type: NotificationType.DANGER
+              } as Notification);
+            } catch (e) {
+              console.log(error._body);
+            }
+          }
+      });
   }
 
   // deleteLink(link : Link){


### PR DESCRIPTION
Display toast notification to indicate that a work item can have a single parent.
Fixes [1609](https://openshift.io/openshiftio/openshiftio/plan/detail/1609)