### PR TITLE
fix(tree-view): Fix drag and drop for re-ordering work items in the list vew.

### DIFF
--- a/src/app/components/planner-list/planner-list.component.less
+++ b/src/app/components/planner-list/planner-list.component.less
@@ -73,7 +73,7 @@
   //Patternfly-ng's tree styles - Start
   .pfng-tree-list {
     .list-pf-item {
-      display: flex;
+
       .list-pf-container {
         padding: 0 15px !important;
       }
@@ -129,8 +129,5 @@
   .tree-list-item {
     display: inline-flex;
     align-items: inherit;
-  }
-  .node-drop-slot.is-dragging-over {
-    height: 66px!important;
   }
 }


### PR DESCRIPTION
This PR allow drag and drop to change order of execution at the root level only.
Does not address drag and drop within the tree.