### PR TITLE
fix(broadcaster): remove broadcaster from provider list

### DIFF
--- a/src/app/components/planner-board/planner-board.module.ts
+++ b/src/app/components/planner-board/planner-board.module.ts
@@ -14,7 +14,7 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { EventService } from './../../services/event.service';
 
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
-import { Broadcaster, Logger } from 'ngx-base';
+import { Logger } from 'ngx-base';
 import {
   AlmIconModule,
   DialogModule,
@@ -55,7 +55,6 @@ if (process.env.ENV == 'inmemory') {
     GlobalSettings,
     WorkItemService,
     WorkItemDataService,
-    Broadcaster,
     Logger,
     {
       provide: HttpService,
@@ -71,7 +70,6 @@ if (process.env.ENV == 'inmemory') {
     GlobalSettings,
     WorkItemService,
     WorkItemDataService,
-    Broadcaster,
     Logger,
     {
       provide: HttpService,

--- a/src/app/components/planner-list/planner-list.module.ts
+++ b/src/app/components/planner-list/planner-list.module.ts
@@ -21,7 +21,7 @@ import {
 } from 'ngx-widgets';
 
 import { ActionModule, ListModule } from 'patternfly-ng';
-import { Broadcaster, Logger } from 'ngx-base';
+import { Logger } from 'ngx-base';
 import { AuthenticationService } from 'ngx-login-client';
 
 import { GlobalSettings } from '../../shared/globals';
@@ -54,7 +54,6 @@ if (process.env.ENV == 'inmemory') {
     BsDropdownConfig,
     GlobalSettings,
     WorkItemService,
-    Broadcaster,
     WorkItemDataService,
     EventService,
     Logger,
@@ -72,7 +71,6 @@ if (process.env.ENV == 'inmemory') {
     GlobalSettings,
     WorkItemService,
     WorkItemDataService,
-    Broadcaster,
     EventService,
     Logger,
     {


### PR DESCRIPTION
This is breaking notifications on the platform because it's created a second service (and events can't be delivered to any  listening component once these modules have been loaded).