### PR TITLE
WIP : refactor jenkinsfile with new npm targets

### DIFF
--- a/deploy/release.groovy
+++ b/deploy/release.groovy
@@ -13,12 +13,16 @@ def ci (){
     }
 
     stage('func test'){
-        container('ui'){
-            sh '''
-            /usr/bin/Xvfb :99 -screen 0 1440x900x24 &
-            npm run func-test
+        dir('runtime'){
+            container('ui'){
+                sh '''
+                /usr/bin/Xvfb :99 -screen 0 1440x900x24 &
+                export API_URL=https://api.prod-preview.openshift.io/api/
+                export NODE_ENV=inmemory
+                npm install
+                ./tests/run_functional_tests.sh smokeTest
             '''
-        }
+            }
     }
 }
 

--- a/deploy/release.groovy
+++ b/deploy/release.groovy
@@ -14,7 +14,10 @@ def ci (){
 
     stage('func test'){
         container('ui'){
-            sh 'npm run func-test'
+            sh '''
+            /usr/bin/Xvfb :99 -screen 0 1440x900x24 &
+            npm run func-test
+            '''
         }
     }
 }

--- a/deploy/release.groovy
+++ b/deploy/release.groovy
@@ -16,12 +16,12 @@ def ci (){
         dir('runtime'){
             container('ui'){
                 sh '''
-                /usr/bin/Xvfb :99 -screen 0 1440x900x24 &
-                export API_URL=https://api.prod-preview.openshift.io/api/
-                export NODE_ENV=inmemory
-                npm install
-                ./tests/run_functional_tests.sh smokeTest
-            '''
+        /usr/bin/Xvfb :99 -screen 0 1440x900x24 &
+        export API_URL=https://api.prod-preview.openshift.io/api/
+        export NODE_ENV=inmemory
+        npm install
+        ./tests/run_functional_tests.sh smokeTest
+'''
             }
     }
 }

--- a/deploy/release.groovy
+++ b/deploy/release.groovy
@@ -2,29 +2,19 @@
 def ci (){
     stage('build planner npm'){
         container('ui'){
-            sh 'npm install'
-            sh 'npm run build'
-            sh 'npm pack dist/'
+            sh 'npm run build-planner'
         }
     }
 
     stage('unit test'){
         container('ui'){
-            sh 'npm run test:unit'
+            sh 'npm run unit-test'
         }
     }
 
     stage('func test'){
-        dir('runtime'){
-            container('ui'){
-                sh '''
-        /usr/bin/Xvfb :99 -screen 0 1440x900x24 &
-        export API_URL=https://api.prod-preview.openshift.io/api/
-        export NODE_ENV=inmemory
-        npm install
-        ./tests/run_functional_tests.sh smokeTest
-'''
-            }
+        container('ui'){
+            sh 'npm run func-test'
         }
     }
 }

--- a/deploy/release.groovy
+++ b/deploy/release.groovy
@@ -23,6 +23,7 @@ def ci (){
         ./tests/run_functional_tests.sh smokeTest
 '''
             }
+        }
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "reinstall": "rimraf node_modules && npm --force cache clean && npm install",
     "test:unit": "gulp test:unit",
     "semantic-release": "semantic-release pre && gulp build && cp -r .git dist && npm publish dist/ && semantic-release post",
-    "build-planner": "npm run install && npm run build && npm pack dist/",
+    "build-planner": "npm install && npm run build && npm pack dist/",
     "unit-test": "npm run test:unit",
     "setupFuncTestEnv": "cd runtime && /usr/bin/Xvfb :99 -screen 0 1440x900x24 & && export API_URL=https://api.prod-preview.openshift.io/api/ && export NODE_ENV=inmemory && npm install",
     "func-test": "npm run -s setupFuncTestEnv && ./tests/run_functional_tests.sh smokeTest"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,8 @@
     "reinstall": "rimraf node_modules && npm --force cache clean && npm install",
     "test:unit": "gulp test:unit",
     "semantic-release": "semantic-release pre && gulp build && cp -r .git dist && npm publish dist/ && semantic-release post",
-    "build-planner": "npm install && npm run build && npm pack dist/",
-    "unit-test": "npm run test:unit",
-    "func-test": "cd runtime && npm install && ./tests/run_functional_tests.sh smokeTest"
+    "build-planner": "npm cache clean && npm install && npm run build && npm pack dist/",
+    "unit-test": "npm run test:unit"
   },
   "license": "Apache-2.0",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "semantic-release": "semantic-release pre && gulp build && cp -r .git dist && npm publish dist/ && semantic-release post",
     "build-planner": "npm install && npm run build && npm pack dist/",
     "unit-test": "npm run test:unit",
-    "setupFuncTestEnv": "/usr/bin/Xvfb :99 -screen 0 1440x900x24 &",
-    "func-test": "npm run -s setupFuncTestEnv && cd runtime && npm install && ./tests/run_functional_tests.sh smokeTest"
+    "func-test": "cd runtime && npm install && ./tests/run_functional_tests.sh smokeTest"
   },
   "license": "Apache-2.0",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "semantic-release": "semantic-release pre && gulp build && cp -r .git dist && npm publish dist/ && semantic-release post",
     "build-planner": "npm install && npm run build && npm pack dist/",
     "unit-test": "npm run test:unit",
-    "setupFuncTestEnv": "cd runtime && /usr/bin/Xvfb :99 -screen 0 1440x900x24 & && export API_URL=https://api.prod-preview.openshift.io/api/ && export NODE_ENV=inmemory && npm install",
-    "func-test": "npm run -s setupFuncTestEnv && ./tests/run_functional_tests.sh smokeTest"
+    "setupFuncTestEnv": "/usr/bin/Xvfb :99 -screen 0 1440x900x24 &",
+    "func-test": "npm run -s setupFuncTestEnv && cd runtime && export API_URL=https://api.prod-preview.openshift.io/api/ && export NODE_ENV=inmemory && npm install && ./tests/run_functional_tests.sh smokeTest"
   },
   "license": "Apache-2.0",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "ngx-widgets": "^2.3.2",
     "patternfly-ng": "^0.13.5",
     "reflect-metadata": "^0.1.10",
+    "rh-ngx-datatable": "^11.1.11",
     "rxjs": "^5.0.1",
     "zone.js": "^0.8.18"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
     "clean:all": "gulp clean:all",
     "reinstall": "rimraf node_modules && npm --force cache clean && npm install",
     "test:unit": "gulp test:unit",
-    "semantic-release": "semantic-release pre && gulp build && cp -r .git dist && npm publish dist/ && semantic-release post"
+    "semantic-release": "semantic-release pre && gulp build && cp -r .git dist && npm publish dist/ && semantic-release post",
+    "build-planner": "npm run install && npm run build && npm pack dist/",
+    "unit-test": "npm run test:unit",
+    "setupFuncTestEnv": "cd runtime && /usr/bin/Xvfb :99 -screen 0 1440x900x24 & && export API_URL=https://api.prod-preview.openshift.io/api/ && export NODE_ENV=inmemory && npm install",
+    "func-test": "npm run -s setupFuncTestEnv && ./tests/run_functional_tests.sh smokeTest"
   },
   "license": "Apache-2.0",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "ngx-widgets": "^2.3.2",
     "patternfly-ng": "^0.13.5",
     "reflect-metadata": "^0.1.10",
-    "rh-ngx-datatable": "^11.1.11",
     "rxjs": "^5.0.1",
     "zone.js": "^0.8.18"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build-planner": "npm install && npm run build && npm pack dist/",
     "unit-test": "npm run test:unit",
     "setupFuncTestEnv": "/usr/bin/Xvfb :99 -screen 0 1440x900x24 &",
-    "func-test": "npm run -s setupFuncTestEnv && cd runtime && export API_URL=https://api.prod-preview.openshift.io/api/ && export NODE_ENV=inmemory && npm install && ./tests/run_functional_tests.sh smokeTest"
+    "func-test": "npm run -s setupFuncTestEnv && cd runtime && npm install && ./tests/run_functional_tests.sh smokeTest"
   },
   "license": "Apache-2.0",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "reinstall": "rimraf node_modules && npm --force cache clean && npm install",
     "test:unit": "gulp test:unit",
     "semantic-release": "semantic-release pre && gulp build && cp -r .git dist && npm publish dist/ && semantic-release post",
-    "build-planner": "npm cache clean && npm install && npm run build && npm pack dist/",
+    "build-planner": "npm install && npm run build && npm pack dist/",
     "unit-test": "npm run test:unit"
   },
   "license": "Apache-2.0",

--- a/src/app/components/planner-list/planner-list.module.ts
+++ b/src/app/components/planner-list/planner-list.module.ts
@@ -20,7 +20,6 @@ import {
   WidgetsModule
 } from 'ngx-widgets';
 
-import { NgxDatatableModule } from '../../../../node_modules/rh-ngx-datatable';
 import { ActionModule, ListModule } from 'patternfly-ng';
 import { Logger } from 'ngx-base';
 import { AuthenticationService } from 'ngx-login-client';

--- a/src/app/components/planner-list/planner-list.module.ts
+++ b/src/app/components/planner-list/planner-list.module.ts
@@ -20,6 +20,7 @@ import {
   WidgetsModule
 } from 'ngx-widgets';
 
+import { NgxDatatableModule } from '../../../../node_modules/rh-ngx-datatable';
 import { ActionModule, ListModule } from 'patternfly-ng';
 import { Logger } from 'ngx-base';
 import { AuthenticationService } from 'ngx-login-client';


### PR DESCRIPTION
just testing


ToDo
- [ ] create new targets in package.json
- [ ] use those targets from jenkinsfile
- [ ] test if fabric8-ui build `thinks` that it is using new planner or it is `really always` using new planner. Do this by following steps
      -  make some breaking changes in planner (only integrated setup should fail)
      -  clean the cache before running `npm run build:prod` in fabric8-ui
