### PR TITLE
fix(test): Update test runner script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ browser_logs.log
 #System Files
 .DS_Store
 Thumbs.db
+*.log

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -33,6 +33,8 @@
     "watch:dev": "npm run build:dev -- --watch",
     "watch:prod": "npm run build:prod -- --watch",
     "watch": "npm run watch:dev",
+    "webdriver:start": "webdriver-manager start --versions.chrome 2.33",
+    "webdriver:update": "webdriver-manager update --versions.chrome 2.33",
     "webpack-dev-server": "webpack-dev-server",
     "webpack": "webpack",
     "test:unit": "karma start tests/karma.conf.js",

--- a/runtime/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
+++ b/runtime/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
@@ -39,10 +39,10 @@ class WorkItemListPage {
       refresh_token: 'somerandomtoken',
       token_type: "bearer"
     }));
-    browser.get("http://localhost:8088/?token_json="+url);
+    browser.get(browser.baseUrl + "/?token_json="+url);
   }
    else {
-     browser.get("http://localhost:8088/");
+     browser.get(browser.baseUrl);
    }
  };
 
@@ -59,7 +59,7 @@ class WorkItemListPage {
  }
 
  workItemByURLId (workItemId) {
-   browser.get("http://localhost:8088/work-item/list/detail/"+ workItemId);
+   browser.get(browser.baseUrl + "/work-item/list/detail/"+ workItemId);
     var theDetailPage = new WorkItemDetailPage (workItemId);
  }
  clickCodeMenuTab () {

--- a/runtime/tests/lib/common.inc.sh
+++ b/runtime/tests/lib/common.inc.sh
@@ -1,0 +1,50 @@
+webdriver_running() {
+  curl --output /dev/null --silent --head --fail 127.0.0.1:4444
+}
+
+wait_for_webdriver() {
+  echo "Waiting for the webdriver to start "
+  # Wait for port 4444 to be listening connections
+  until webdriver_running ; do
+    sleep 1
+    echo -n .
+  done
+  echo
+  echo "Webdriver manager up and running - OK"
+  echo
+}
+
+start_webdriver() {
+  local log_file="$1"; shift
+  echo "Webdriver will log to: $log_file"
+  # Update webdriver
+  echo "Updating Webdriver and Selenium..."
+  npm run webdriver:update >> $log_file 2>&1
+  # Start selenium server just for this test run
+  echo "Starting Webdriver and Selenium..."
+  npm run webdriver:start >> "$log_file" 2>&1 &
+}
+
+start_planner() {
+  local log_file="$1"; shift
+  echo "NODE_ENV=inmemory mode set; Planner will use mock data"
+  echo "Planner will log to: $log_file"
+  echo "Starting local development server"
+  NODE_ENV=inmemory $(npm bin)/webpack-dev-server --inline --progress --host 0.0.0.0 --port 8088 >> $log_file 2>&1 &
+}
+
+planner_running() {
+  curl --output /dev/null --silent --fail localhost:8088
+}
+
+wait_for_planner() {
+  echo "Waiting for the planner to start "
+  # Wait for port 4444 to be listening connections
+  until planner_running ; do
+    sleep 1
+    echo -n .
+  done
+  echo
+  echo "Planner up and running - OK"
+  echo
+}

--- a/runtime/tests/protractor.config.js
+++ b/runtime/tests/protractor.config.js
@@ -3,14 +3,14 @@ let SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 exports.config = {
     useAllAngular2AppRoots: true,
     getPageTimeout: 30000,
+    directConnect: process.env.DIRECT_CONNECT === 'true',
     seleniumAddress: 'http://localhost:4444/wd/hub',
     specs: ['./../src/tests/**/*.spec.js'],
     exclude: ['./../src/tests/**/*test-template.spec.js','./../src/tests/**/*work-item-dynamic-fields.spec.js','./../src/tests/**/EXCLUDED/*.spec.js'],
     suites: {
-      smokeTest: './../src/tests/**/smokeTest.spec.js',
-      fullTest:  './../src/tests/**/*.spec.js'
+        smokeTest: './../src/tests/**/smokeTest.spec.js',
+        fullTest:  './../src/tests/**/*.spec.js'
     },
-
     jasmineNodeOpts: {
         isVerbose: true,
         showColors: true,
@@ -19,33 +19,29 @@ exports.config = {
         print: function () {
         }
     },
-
     troubleshoot: true,
-
     capabilities: {
-      'browserName': 'chrome',
-//      'maxInstances': 2,
-      'shardTestFiles': true,
-      'loggingPrefs': {
-      'driver': 'WARNING',
-      'server': 'WARNING',
-      'browser': 'INFO'
-      },
-      'chromeOptions': {
-//      'args': [ '--no-sandbox', '--window-workspace=1']
-       'args': [ '--no-sandbox']
-      }
+        'browserName': 'chrome',
+        'shardTestFiles': true,
+        'loggingPrefs': {
+            'driver': 'WARNING',
+            'server': 'WARNING',
+            'browser': 'INFO'
+        },
+        'chromeOptions': {
+            'args': process.env.HEADLESS_MODE === 'true'? ['--no-sandbox', '--headless'] : ['--no-sandbox']
+        }
     },
 
     onPrepare: function () {
-      jasmine.getEnv().addReporter(new SpecReporter({
+        jasmine.getEnv().addReporter(new SpecReporter({
         spec: {
-          displayStacktrace: true,
-          displayDuration: true,
+            displayStacktrace: true,
+            displayDuration: true,
         },
         summary: {
-          displayDuration: true
+            displayDuration: true
         }
-      }));
+        }));
     }
 };

--- a/runtime/tests/run_functional_tests.sh
+++ b/runtime/tests/run_functional_tests.sh
@@ -1,73 +1,59 @@
 #!/usr/bin/env bash
 
-LOGFILE=$(pwd)/functional_tests.log
-BROWSERLOGS=$(pwd)/browser_logs.log
-echo Using logfile $LOGFILE and $BROWSERLOGS
+declare -r SCRIPT_PATH=$(readlink -f "$0")
+declare -r SCRIPT_DIR=$(cd $(dirname "$SCRIPT_PATH") && pwd)
 
-# For the functional tests, we are mocking the core
-export NODE_ENV=inmemory
-OS=$(uname -a | awk '{print $1;}')
+source "$SCRIPT_DIR/lib/common.inc.sh"
 
-# Download dependencies
-echo -n Updating Webdriver and Selenium...
-node_modules/protractor/bin/webdriver-manager update --versions.chrome 2.33
-# Start selenium server just for this test run
-echo -n Starting Webdriver and Selenium...
-(node_modules/protractor/bin/webdriver-manager --versions.chrome 2.33 start >>$LOGFILE 2>&1 &)
-# Wait for port 4444 to be listening connections
-if [ $OS = 'Darwin' ]
-then
-  while ! (nc -w 1 127.0.0.1 4444 </dev/null >/dev/null 2>&1); do sleep 1; done
-else
-  while ! (ncat -w 1 127.0.0.1 4444 </dev/null >/dev/null 2>&1); do sleep 1; done
-fi
-echo done.
+main() {
+  local base_url=${BASE_URL:-"http://localhost:8088/"}
+  local protractor="$(npm bin)/protractor"
+  local suite=${1:-fullTest}
 
-# Start the web app
-echo -n Starting Planner development server...
-(../node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --progress --host 0.0.0.0 --port 8088 >>$LOGFILE 2>&1 &)
-# Wait for port 8088 to be listening connections
-if [ $OS = 'Darwin' ]
-then
-  while ! (nc -w 1 127.0.0.1 8088 </dev/null >/dev/null 2>&1); do sleep 1; done
-else
-  while ! (ncat -w 1 127.0.0.1 8088 </dev/null >/dev/null 2>&1); do sleep 1; done
-fi
+  # BASE_URL is set means planner is already running.
+  # Start planner only if BASE_URL is not set
+  if [[ -z ${BASE_URL+x} ]]; then
+    echo "Starting Planner in inmemory mode"
+    local log_file="${SCRIPT_DIR}/planner.log"
+    start_planner "$log_file"
+    wait_for_planner
+  fi
 
-echo done.
+  if [[ ${DIRECT_CONNECT:-false} == false ]]; then
+    echo "DIRECT_CONNECT not set; Using webdriver. Tests may run slow .. checking webdriver status"
+    echo
+    webdriver_running || {
+      local log_file="${SCRIPT_DIR}/webdriver.log"
+      start_webdriver "$log_file"
+      wait_for_webdriver
+    }
+  else
+    echo "DIRECT_CONNECT is set; using direct connection (faster)"
+    echo
+  fi
 
-# Retrieve index.html to trigger webpack to build the source
-echo -n Building source...
-# Wait for the build to finish (index.html is delivered)
-curl http://localhost:8088/ -o /dev/null -s
-echo done.
+  if [[ ${HEADLES_MODE:-false} == false ]]; then
+    echo "HEADLESS_MODE is set. Chrome will run in headless mode"
+    echo
+  fi
 
-# Finally run protractor
-echo Running tests...
-if [ -z "$1" ]
-  then
-    ../node_modules/protractor/bin/protractor tests/protractor.config.js 2>&1
-else
-    ../node_modules/protractor/bin/protractor tests/protractor.config.js --suite $1 2>&1
-fi
+  $protractor --baseUrl "${base_url}" "$SCRIPT_DIR/protractor.config.js" --suite "${suite}"
 
-TEST_RESULT=$?
+  TEST_RESULT=$?
 
-# Cleanup webdriver-manager and web app processes
-if [ $OS = 'Darwin' ]
-then
-  kill -9 $(lsof -ti tcp:4444)
-  kill -9 $(lsof -ti tcp:8088)
-else
   fuser -k -n tcp 4444
   fuser -k -n tcp 8088
-fi
 
-# Return test result
-if [ $TEST_RESULT -eq 0 ]; then
-  echo 'Functional tests OK'
-  exit 0
-else
-  echo 'Functional tests FAIL'
-  exit 1
-fi
+  # Return test result
+  if [ $TEST_RESULT -eq 0 ]; then
+    echo 'Functional tests OK'
+    exit 0
+  else
+    echo 'Functional tests FAIL'
+    exit 1
+  fi
+}
+
+main "$@"
+
+


### PR DESCRIPTION
The `run_functional_tests.sh` script now has support for
- User defined `BASE URL`
- `DIRECT CONNECT`protractor flag
- Using chrome in headless mode

Also, local web server for serving planner will be started only if `BASE_URL` is not defined.

To run protractor in `directConnect` mode
`DIRECT_CONNECT=true npm run test:funcsmoke`

To run chrome in `headless` mode
`HEADLESS_MODE=true npm run test:funcsmoke`

To run tests against an already running planner server
`BASE_URL=http://localhost:8080 npm run test:funcsmoke`

NOTE -  The builds for this PR are failing due to `chrome` crashing in `xvfb` display environment. 
The PR https://github.com/fabric8-ui/fabric8-planner/pull/2370 fixes the chrome crashes.