### PR TITLE
fix(script): Bootstrap.sh can now generate fabric8-ui docker image

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,119 +1,106 @@
+##
+# Bash script to generate fabric8-ui image with latest planner source
+# NOTE - The script assumes the user has all the required node modules in fabric8-planner and
+#        fabric8-ui directory.
+##
 #!/bin/bash
-set -x
+set -e # exit immediately when a command fails
 
-echo "Setting up working directories..."
-BASEPATH=`pwd -P`
-PLANNERPATH=""
-PLATFORMPATH=""
-DRYRUN=false
+build_and_install_planner() {
+    print_success "STEP 1/4 - Building planner library..."
+    cd $PLANNER_PATH
+    npm run build:library || {
+        print_err "Failed to build fabric8-planner. Please fix the error and try again."
+        exit 1
+    }
+    # Pack fabric8-planner into fabric8-planner@0.0.0-development.tar.gz
+    package_name=$(npm pack dist)
+    print_success "STEP 1/4 - Building planner library... - Done"
+    install_planner "$package_name"
+}
 
-echo "Parsing CLI arguments..."
-for i in "$@"
-do
-case $i in
-    --planner=* )
-        if [[ -d "${i#*=}" ]]; then
-            # Provided path _is_ indeed a directory
-            cd ${i#*=}
-            # Let's validate if it contains the Planner source code
-            if [[ $(npm view . name) = fabric8-planner ]]; then
-                # The path seems to contain package.json which reports to be Planner source
-                PLANNERPATH=${i#*=}
-                echo "Planner path is set to: $PLANNERPATH"
-            else
-                echo -e "\e[1;31mCan't resolve source at provided Planner path\e[0m"
-                exit 1
-            fi
-        else
-            echo -e "\e[1;31mProvided Planner path is invalid\e[0m"
-            exit 1
-        fi
-        shift;;
-    --platform=* )
-        if [[ -d "${i#*=}" ]]; then
-            # Provided path _is_ indeed a directory
-            cd ${i#*=}
-            # Let's validate if it contains the Platform source code
-            if [[ $(npm view . name) = fabric8-ui ]]; then
-                # The path seems to contain package.json which reports to be Platform source
-                PLATFORMPATH=${i#*=}
-                echo "Platform path is set to: $PLATFORMPATH"
-            else
-                echo -e "\e[1;31mCan't resolve source at provided Platform path\e[0m"
-                exit 1
-            fi
-        else
-            echo -e "\e[1;31mProvided Platform path is invalid\e[0m"
-            exit 1
-        fi
-        shift;;
-    --dryrun )
-        DRYRUN=true
-        shift;;
-    * )
-        ;;
-esac
-done
+build_docker_image() {
+    print_success "STEP 3/4 - Building fabric8-ui docker image..."
+    cd $UI_PATH
+    docker build -t fabric8-ui:test -f Dockerfile.deploy .
+    print_success "STEP 3/4 - Building fabric8-ui docker image... - Done\nSuccessfully built fabric8-ui:test docker image"
+}
 
-echo "Validating repositories..."
-if [[ -z $PLANNERPATH ]]; then
-    echo "Local Planner repo path wasn't provided, cloning from upstream to '/tmp/planner':"
-    PLANNERPATH=/tmp/planner
-    git clone https://github.com/fabric8-ui/fabric8-planner.git $PLANNERPATH
-fi
-if [[ -z $PLATFORMPATH ]]; then
-    echo "Local Platform repo path wasn't provided, cloning from upstream to '/tmp/platform':"
-    PLATFORMPATH=/tmp/platform
-    git clone https://github.com/fabric8-ui/fabric8-ui.git $PLATFORMPATH
-fi
+build_ui() {
+    print_success "STEP 4/4 - Building fabric8-ui library..."
+    cd $UI_PATH
+    npm run build:prod || {
+        print_err "Failed to build fabric8-ui. Please fix the error and try again."
+        exit 1
+    }
+    print_success "STEP 4/4 - Building fabric8-ui library... - Done"
+}
 
-echo "Setting up some environment variables, which ideally should be set in app as defaults..."
-export FABRIC8_WIT_API_URL="https://api.prod-preview.openshift.io/api/"
-export FABRIC8_RECOMMENDER_API_URL="https://api-bayesian.dev.rdu2c.fabric8.io/api/v1/"
-export FABRIC8_FORGE_API_URL="https://forge.api.prod-preview.openshift.io"
-export FABRIC8_SSO_API_URL="https://sso.prod-preview.openshift.io/"
-export FABRIC8_REALM="fabric8-test"
+install_planner() {
+    print_success "STEP 2/4 - Installing new fabric8-planner into fabric8-ui..."
+    cd $UI_PATH
+    # Replace installed fabric8-planner with the one we just built
+    npm install $PLANNER_PATH/$1 || {
+        print_err "Failed to install fabric8-planner in fabric8-ui. Please fix the error and try again."
+        exit 1
+    }
+    print_success "STEP 2/4 - Installing new fabric8-planner into fabric8-ui... - Done"
+    # Remove the fabric8-planner@0.0.0-development.tar.gz file
+    rm $PLANNER_PATH/$1
+}
 
-echo "Installing global prerequisites..."
-npm install -g rimraf gulp webpack webpack-merge
+print_success() {
+    GREEN="\e[32m"
+    print_msg ${GREEN} "$1"
+}
 
-cd $PLANNERPATH
-if [[ $DRYRUN = true ]]
-then
-    echo "Dry running mock build (bypasses actual build step)..."
-    mkdir -p dist
-    cp package.json dist/
-else
-    echo "Building planner library..."
-    npm install
-    npm run build:library
-fi
+print_err() {
+    RED="\e[31m"
+    print_msg ${RED} "$1"
+}
 
-echo "Starting docker..."
-service docker start
+print_msg() {
+    RESET="\e[0m"
+    printf "\n$1======================================================================\n"
+    printf "${2}\n"
+    printf "======================================================================${RESET}\n"
+}
 
-echo "Switching over to f8ui..."
-cd $PLATFORMPATH
+validate_fabric8_ui() {
+    cd $1
+    # Let's validate if it contains the fabric8-ui source code
+    if [[ $(npm view . name) != fabric8-ui ]]; then
+        # The path doesn't contain package.json which reports to be fabric8-ui source
+        print_err "Can't resolve source at provided fabric8-ui path\nPlease verify the path provided and try again"
+        exit 1
+    fi
+}
 
-echo "Alternate build step, without using builder image, similar to f8ui/release.groovy..."
-if [[ $DRYRUN = true ]]
-then
-    echo "Dry running mock build (bypasses actual build step)..."
-    mkdir -p dist
-    echo 'Mock Build' > ./dist/index.html
-else
-    echo "Linking planner to platform within f8ui build container..."
-    npm install
-    npm link $PLANNERPATH/dist
+main() {
+    SCRIPT_PATH=$(readlink -f "$0")
+    BASE_PATH=$(dirname "$SCRIPT_PATH")
 
-    echo "Building platform with integrated planner..."
-    npm run build:prod
-fi
+    if [[ -z "$1" ]]; then
+        print_err "No argument supplied\nUsage: ./bootstrap.sh FABRIC8_UI_PATH"
+        exit 1
+    fi
 
-echo "Generating f8ui integrated planner image from build artifacts..."
-docker rm fabric8-planner-platform
-docker rmi fabric8-planner-platform
-docker build -t fabric8-planner-platform -f Dockerfile.deploy .
+    # Check provided argument is fabric8-ui directory
+    validate_fabric8_ui $1
+    UI_PATH=$1
+    PLANNER_PATH=$(dirname "$BASE_PATH")
 
-# echo "Running the container; visit http://localhost:8080/ on host browser..."
-# docker run -it -p 8088:8080 --name=fabric8-planner-platform fabric8-planner-platform
+    # Step 1 and 2 - Build planner and install it in fabric8-ui
+    build_and_install_planner
+
+    # Step 3 - Build fabric8-ui library
+    build_ui
+
+    # Step 4 - Build fabric8-ui docker image
+    build_docker_image
+
+    print_success "All steps successfully completed.\nRun the fabric8-ui image as
+$ docker run -e PROXY_PASS_URL='https://api.free-int.openshift.com' -p 8080:8080 fabric8-ui:test"
+}
+
+main "$@"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -95,32 +95,6 @@ service docker start
 echo "Switching over to f8ui..."
 cd $PLATFORMPATH
 
-# echo "Making f8ui-builder image and starting the container..."
-# docker stop fabric8-ui-builder && docker rm fabric8-ui-builder
-# docker rmi fabric8-ui-builder
-# docker build -t fabric8-ui-builder -f Dockerfile.builder .
-# docker run -d --name=fabric8-ui-builder -t -v $PLATFORMPATH/dist:/dist -v $PLANNERPATH/dist:/planner fabric8-ui-builder
-
-
-# if [[ $DRYRUN = true ]]
-# then
-#     echo "Dry running mock build (bypasses actual build step)..."
-#     docker exec -u root fabric8-ui-builder echo 'Mock Build' > ./dist/index.html
-# else
-#     echo "Linking planner to platform within f8ui build container..."
-#     docker exec -u root fabric8-ui-builder npm install
-#     docker exec -u root fabric8-ui-builder npm link /planner
-
-#     echo "Building platform with integrated planner..."
-#     docker exec -u root fabric8-ui-builder npm run build:prod
-# fi
-
-# echo "Copy over the build artifacts from container to host..."
-# echo ""
-# echo "This is only needed because the platform build executes 'npm run clean'"
-# echo "which removes the 'dist' directory from the host, unlinking the volume"
-# docker cp fabric8-ui-builder:/home/fabric8/fabric8-ui/dist $PLATFORMPATH/
-
 echo "Alternate build step, without using builder image, similar to f8ui/release.groovy..."
 if [[ $DRYRUN = true ]]
 then
@@ -140,11 +114,6 @@ echo "Generating f8ui integrated planner image from build artifacts..."
 docker rm fabric8-planner-platform
 docker rmi fabric8-planner-platform
 docker build -t fabric8-planner-platform -f Dockerfile.deploy .
-
-# echo "Cleaning up intermediate build container and image..."
-# docker stop fabric8-ui-builder
-# docker rm fabric8-ui-builder
-# docker rmi fabric8-ui-builder
 
 # echo "Running the container; visit http://localhost:8080/ on host browser..."
 # docker run -it -p 8088:8080 --name=fabric8-planner-platform fabric8-planner-platform


### PR DESCRIPTION
A user can generate `fabric8-ui` docker image with latest planner source using `bootstrap.sh` script

How to run - 
`./bootstrap.sh PATH_TO_FABRIC8_UI`

Result - 
`fabric8-planner-platform` docker image is built.
To run the image `docker run -e PROXY_PASS_URL="https://api.free-int.openshift.com" -p 8080:8080 fabric8-planner-platform`


NOTE - The script assumes that all the required node modules are already installed and won't install any packages.
