### PR TITLE
Planner-datatable:  move bottom quickAdd to top

### DIFF
--- a/runtime/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
+++ b/runtime/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
@@ -102,15 +102,6 @@ class WorkItemListPage {
    return this.workItemQuickAddTitle.sendKeys(keys);
  }
 
- get workItemQuickAddDesc () {
-   return element(by.css(".f8-quickadd-desc"));
- }
-
- typeQuickAddWorkItemDesc (keys) {
-   browser.wait(until.presenceOf(this.workItemQuickAddDesc), constants.WAIT, 'Failed to find workItemQuickAddDesc');
-   return this.workItemQuickAddDesc.sendKeys(keys);
- }
-
  /* Access the Kebab element relative to its parent workitem */
  workItemKebabButton (parentElement) {
    browser.wait(until.presenceOf(parentElement.element(by.id("dropdownKebabRight"))), constants.WAIT, 'Failed to find clickWorkItemKebabButton');
@@ -220,21 +211,12 @@ class WorkItemListPage {
     return this.workItemPopUpDeleteCancelConfirmButton.click();
   }
 
-  get openButton () {
-    return element(by.css(".f8-quickadd__addwi-savebtn"));
-  }
-
   quickAddbuttonById () {
     return element(by.css("f8-quickadd-container"));
   }
 
-  clickWorkItemQuickAdd () {
-    browser.wait(until.presenceOf(this.openButton), constants.WAIT, 'Failed to find the open button');
-    return this.openButton.click();
-  }
-
   get saveButton () {
-    return  element(by.css(".f8-quickadd__wiblk-btn-add"));
+    return  element(by.id("quickadd-save"));
   }
 
   clickQuickAddSave () {

--- a/runtime/src/tests/work-item/work-item-list/smokeTest.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/smokeTest.spec.js
@@ -44,7 +44,6 @@ describe('Work item list', function () {
 
   /* User can read, update, remove assignee on a workitem  */
   it('User can read, update, remove assignee', function() {
-    page.clickWorkItemQuickAdd();
     page.typeQuickAddWorkItemTitle(WORK_ITEM_TITLE);
     page.clickQuickAddSave().then(function() {
       var detailPage = page.clickWorkItemTitle(WORK_ITEM_TITLE);
@@ -69,9 +68,7 @@ describe('Work item list', function () {
   /* Create a new workitem, fill in the details, save, retrieve, update, save, verify updates are saved */
   it('should find and update the workitem through its detail page', function() {
     /* Create a new workitem */
-    page.clickWorkItemQuickAdd();
     page.typeQuickAddWorkItemTitle(WORK_ITEM_TITLE);
-    page.typeQuickAddWorkItemDesc(WORK_ITEM_DESCRIPTION);
     page.clickQuickAddSave().then(function() {
       expect(page.workItemTitle(page.firstWorkItem)).toBe(WORK_ITEM_TITLE);
       /* Fill in/update the new work item's title and details field */

--- a/src/app/components/labels/labels.component.html
+++ b/src/app/components/labels/labels.component.html
@@ -12,9 +12,8 @@
       <i class="pficon-close pointer" (click)="removeLabel(label, $event)"></i>
     </span>
   </span>
-  <span dropdown class="pull-left margin-h-5 dropdown" placement="right">
-    <span dropdownToggle (click)="moreClick($event)" class="dib dropdown-toggle pointer"
-      *ngIf="truncateAfter!==undefined && _labels.length > 4">
+  <span *ngIf="truncateAfter!==undefined && _labels.length > 4" dropdown class="label dropdown" placement="right">
+    <span dropdownToggle (click)="moreClick($event)" class="dib dropdown-toggle pointer">
         {{ _labels.length - truncateAfter }}+
       </span>
       <ul *dropdownMenu class="dropdown-menu label-dropdown dropdown-menu-right">

--- a/src/app/components/planner-list/planner-list.component.html
+++ b/src/app/components/planner-list/planner-list.component.html
@@ -55,7 +55,17 @@
       </toolbar-panel>
     </div>
     <!-- tableConfig Dropdown -->
-    <div class="col-md-12" style="height: 30px;">
+    <div class="col-md-12" style="height: 50px;">
+        <div class="f8-wi-list__quick-add width-100 pull-left"
+        id="workItemList_up_quickAdd"
+        *ngIf="loggedIn"
+        #quickaddHeight>
+        <alm-work-item-quick-add
+          [WITypes]="workItemTypes"
+          [wilistview]="'wi-table-view-top'"
+          (close)="close($event)">
+        </alm-work-item-quick-add>
+      </div>
         <div class="f8-wi-list__settings planner-hack-dropdown">
             <div class="dropdown-kebab-pf pull-right dropdown margin-left-10"
                   dropdown
@@ -169,7 +179,7 @@
               [width]="50"
               [resizeable]="false"
               [sortable]="false"
-              [cellClass]="'cell-overflow'"
+              [cellClass]="'cell-class'"
               [frozenLeft]="false">
               <ng-template let-row="row" let-expanded="expanded" ngx-datatable-cell-template>
                 <a class="quick-add-icon"
@@ -192,7 +202,7 @@
             [resizeable]="false"
             [width]="c.width"
             [sortable]="c.name === 'Title'"
-            [cellClass]="'cell-overflow'"
+            [cellClass]="'cell-class'"
             [headerClass]="'header-cell'">
               <ng-template ngx-datatable-cell-tree-expander *ngIf="c.name==='Title'">
                 <i class="fa fa-angle-right tree-icon"></i>
@@ -207,7 +217,7 @@
               </ng-template>
 
               <ng-template ngx-datatable-cell-tree-loader *ngIf="c.name==='Title'">
-                <div class="spinner spinner-xs margin-top-5"></div>
+                <div class="spinner spinner-xs icon-loader margin-top-15"></div>
               </ng-template>
 
               <ng-template let-row="row"
@@ -228,8 +238,7 @@
             [width]="120"
             [resizeable]="false"
             [sortable]="false"
-            [cellClass]="'cell-overflow'"
-            [headerClass]="'cell-overflow'"
+            [cellClass]="'cell-class'"
             [frozenRight]="false">
             <ng-template let-row="row"
               ngx-datatable-cell-template>
@@ -304,17 +313,6 @@
         id="workItemList_Error"
         *ngIf="error">
         {{error}}
-      </div>
-      <div class="f8-wi-list__quick-add width-100 pull-left"
-        id="workItemList_quickAdd"
-        *ngIf="loggedIn"
-        #quickaddHeight>
-        <alm-work-item-quick-add
-          [WITypes]="workItemTypes"
-          [wilistview]="'wi-list-view'"
-          (close)="close($event)"
-          (workItemCreate)="onCreateWorkItem($event)">
-        </alm-work-item-quick-add>
       </div>
     </div>
   </section>

--- a/src/app/components/planner-list/planner-list.component.less
+++ b/src/app/components/planner-list/planner-list.component.less
@@ -63,7 +63,7 @@
     }
     &__settings {
       position: absolute;
-      top: 2px;
+      top: 10px;
       right: 15px;
       &-dropdown {
         width: 100%;
@@ -119,7 +119,7 @@
     }
     &__quick-add {
       position: absolute;
-      bottom: 0;
+      bottom: 10px;
     }
     &__quick-add-table {
       position: absolute;
@@ -209,8 +209,11 @@ button.btn.btn-link.dropdown-toggle:focus {
 /// ng x-datatables css
 
 
-.cell-overflow {
+.cell-class {
   overflow: visible !important;
+  padding-top: 3px !important;
+  padding-bottom: 4px !important;
+  line-height: 44px !important;
 }
 
 .header-cell{
@@ -298,4 +301,8 @@ a.quick-add-icon, .f8-action-icon {
     opacity: .4;
     cursor: not-allowed;
   }
+}
+.icon-loader {
+  margin-left: -4px;
+  margin-right: 6px;
 }

--- a/src/app/components/planner-list/planner-list.component.ts
+++ b/src/app/components/planner-list/planner-list.component.ts
@@ -693,19 +693,13 @@ export class PlannerListComponent implements OnInit, AfterViewChecked, OnDestroy
       if (index > -1) {
         this.datatableWorkitems[index].treeStatus = 'loading';
         this.table.rowDetail.collapseAllRows();
+        this.detailExpandedRows = [];
       }
     }
   }
 
   onCreateWorkItem(workItem) {
-    let resolveItem = this.workItemService.resolveWorkItems(
-      [workItem],
-      this.iterations,
-      [],
-      this.workItemTypes,
-      this.labels
-    );
-    this.workItems = [...resolveItem, ...this.workItems];
+    this.workItems = [workItem, ...this.workItems];
     this.datatableWorkitems = [
       ...this.tableWorkitem([this.workItems[0]]),
       ...this.datatableWorkitems
@@ -1039,13 +1033,20 @@ export class PlannerListComponent implements OnInit, AfterViewChecked, OnDestroy
 
   toggleExpandRow(row, quickAddEnabled = true) {
     if (quickAddEnabled) {
-      this.detailExpandedRows.forEach(r => {
-        if (r.id !== row.id)
+      const index = this.detailExpandedRows.findIndex(r => r.id === row.id);
+      if (index > -1) {
+        // For collapsing
+        this.table.rowDetail.toggleExpandRow(this.detailExpandedRows[index]);
+        this.detailExpandedRows.splice(index, 1); 
+      } else {
+        // For expanding
+        this.detailExpandedRows.forEach(r => {
           this.table.rowDetail.toggleExpandRow(r);
-      });
-      this.detailExpandedRows = [];
-      this.table.rowDetail.toggleExpandRow(row);
-      this.detailExpandedRows.push(row);
+        });
+        this.detailExpandedRows = [];
+        this.table.rowDetail.toggleExpandRow(row); 
+        this.detailExpandedRows.push(row);
+      }
     }
   }
 

--- a/src/app/components/work-item-cell/work-item-cell.component.html
+++ b/src/app/components/work-item-cell/work-item-cell.component.html
@@ -30,9 +30,9 @@
 <!-- Status -->
 
 <div *ngIf="col === 'status'">
-  <span class="pull-left padding-right-5 padding-top-4" almIcon [iconType]="row.status">
+  <span class="padding-right-5 padding-top-4" almIcon [iconType]="row.status">
   </span>
-  <span class="pull-left">
+  <span>
     {{row.status}}
   </span>
 </div>

--- a/src/app/components/work-item-quick-add/work-item-quick-add.component.html
+++ b/src/app/components/work-item-quick-add/work-item-quick-add.component.html
@@ -1,7 +1,7 @@
 <!-- Table Inline Quick Add -->
 <div class="col-xs-12 col-sm-12 col-md-12 f8-quickadd-table__wiblk"
-  *ngIf="wilistview === 'wi-table-view'">
-  <b class="pull-left" style="padding-right: 20px;">Add Child Work Item</b>
+  *ngIf="wilistview === 'wi-table-view' || wilistview === 'wi-table-view-top'">
+  <b class="pull-left" style="padding-right: 20px;">{{wilistview === 'wi-table-view'? 'Add Child Work Item' : 'Add Work Item'}}</b>
   <!-- type dropdown -->
   <div class="pull-left">
     <div class="dropdown-kebab-pf" dropdown>
@@ -29,8 +29,8 @@
   </div>
 
   <div class="f8-quickadd__wiblk-story">
-    <div class="col-xs-12 col-sm-6 col-md-6
-      f8-quickadd__wiblk-storyinput">
+    <div [ngClass]="wilistview === 'wi-table-view'? 'col-xs-12 col-sm-6 col-md-6' : 'col-xs-12 col-sm-8 col-md-8'" 
+      class="f8-quickadd__wiblk-storyinput">
       <input class="form-control col-xs-12 col-sm-12
         col-md-12 f8-quickadd-input"
         type="text"
@@ -58,87 +58,6 @@
   </div>
 </div>
 <!-- Table Inline Quick Add Ends -->
-
-<!-- List View Quick -->
-<div class="col-xs-12 col-sm-12 col-md-12
-  f8-quickadd f8-quickadd-container"
-  *ngIf="wilistview === 'wi-list-view'" >
-  <div class="col-xs-12 col-sm-12 col-md-12 f8-quickadd__addwi"
-    (click)="toggleQuickAdd()"
-    [ngClass]="{'show' : showQuickAddBtn, 'hide' : !showQuickAddBtn}">
-    <a class="f8-quickadd__addwi-savebtn">
-      <i class='pficon-add-circle-o dib'></i>
-    </a>
-    <span class="padding-left-5">Create Work Item</span>
-  </div>
-  <div class="col-xs-12 col-sm-12 col-md-12 f8-quickadd__wiblk"
-    *ngIf="showQuickAdd">
-    <!-- type dropdown -->
-    <div class="dropdown-kebab-pf pull-left" dropdown [dropup]="true">
-      <button class="btn btn-default dropdown-toggle padding-v-0"
-        type="button"
-        dropdownToggle>
-        <i class="fa dib"
-          [ngClass]="selectedType?selectedType.attributes.icon:''"></i>
-        <span class="fa fa-angle-up"></span>
-      </button>
-      <ul class="dropdown-menu"
-        role="menu"
-        aria-labelledby="dropdownKebab"
-        *dropdownMenu>
-        <li *ngFor="let type of availableTypes"
-            role="menuitem"
-            (click)="selectType($event, type)">
-          <a class="dropdown-item" href="#">
-            <i class="fa pull-left"
-              [ngClass]="type.attributes.icon"></i>&nbsp;{{type.attributes.name}}
-          </a>
-        </li>
-      </ul>
-    </div>
-    <div class="f8-quickadd__wiblk-story">
-      <div class="col-xs-12 col-sm-6 col-md-6
-        f8-quickadd__wiblk-storyinput">
-        <input class="form-control col-xs-12 col-sm-12
-          col-md-12 f8-quickadd-input"
-          type="text"
-          placeholder="Work Item Title"
-          #quickAddTitle
-          [(ngModel)]="workItem.attributes['system.title']"
-          (keyup.enter)="save($event)"
-          (keyup)="checkTitle()"  required/>
-      </div>
-      <div class="col-xs-12 col-sm-6 col-md-6 mobdn">
-        <textarea
-          class="form-control pull-left f8-quickadd-desc"
-          type="text"
-          rows="1"
-          placeholder="Work Item Description"
-          #quickAddDesc
-          [(ngModel)]="workItem.attributes['system.description']"
-          [style.height]="descHeight"
-          [style.resize]="descResize"
-          (keydown.enter)="save($event)"
-          (keyup.enter)="preventDef($event)"
-          (keyup)="checkDesc()">
-        </textarea>
-      </div>
-    </div>
-    <div class="f8-quickadd__wiblk-btn pull-right">
-      <button class="btn btn-primary pull-left f8-quickadd__wiblk-btn-add"
-        #quickAddSubmit
-        [ngClass]="{'': validTitle,'disabled':!validTitle}"
-        (click)="save($event)">
-        <i class="fa fa-check"></i>
-      </button>
-      <button class="btn btn-default pull-right
-        f8-quickadd__wiblk-btn-close"
-        (click)="toggleQuickAdd()">
-        <i class="pficon-close"></i>
-      </button>
-    </div>
-  </div>
-</div>
 
 <!-- Quick ADD Template for Board View -->
 <div class="f8-quickadd-card card-pf f8-quickadd-container"

--- a/src/app/components/work-item-quick-add/work-item-quick-add.component.html
+++ b/src/app/components/work-item-quick-add/work-item-quick-add.component.html
@@ -44,6 +44,7 @@
 
   <div class="f8-quickadd__wiblk-btn pull-left">
     <button class="btn btn-primary f8-quickadd__wiblk-btn-add margin-right-20"
+      id="quickadd-save"
       #quickAddSubmit
       [ngClass]="{'': validTitle,'disabled':!validTitle}"
       (click)="save($event)">

--- a/src/app/components/work-item-quick-add/work-item-quick-add.component.ts
+++ b/src/app/components/work-item-quick-add/work-item-quick-add.component.ts
@@ -46,6 +46,9 @@ export class WorkItemQuickAddComponent implements OnInit, OnDestroy, AfterViewIn
       this.availableTypes = cloneDeep(this.allWorkItemTypes);
       if(this.availableTypes.length){
         this.selectedType = this.availableTypes[0];
+        if (this.wilistview === 'wi-table-view-top') {
+          this.createWorkItemObj();
+        }
       }
     }
   };
@@ -310,18 +313,6 @@ export class WorkItemQuickAddComponent implements OnInit, OnDestroy, AfterViewIn
     this.qaTitle.nativeElement.focus();
   }
 
-  toggleQuickAdd(): void {
-    this.showQuickAdd = !this.showQuickAdd;
-    this.showQuickAddBtn = !this.showQuickAddBtn;
-    if (!this.showQuickAdd) {
-      this.workItem.attributes['system.description'] = '';
-      this.workItem.attributes['system.title'] = '';
-      this.validTitle = false;
-      this.descHeight = this.initialDescHeight ? this.initialDescHeight : 'inherit';
-    } else {
-      this.createWorkItemObj();
-    }
-  }
 
   preventDef(event: any) {
     event.preventDefault();


### PR DESCRIPTION
This PR introduces these Changes

- Move bottom QuickAdd to Top
- fix: opens two quickAdd simultaneously
- fix CSS for labels and each row-cell