### PR TITLE
fix(tests): Increase Jasmine timeout to 5 minutes

### DIFF
--- a/runtime/tests/protractor.config.js
+++ b/runtime/tests/protractor.config.js
@@ -15,7 +15,7 @@ exports.config = {
         isVerbose: true,
         showColors: true,
         includeStackTrace: true,
-        defaultTimeoutInterval: 60000,
+        defaultTimeoutInterval: 300000,  // 5 minute timeout
         print: function () {
         }
     },


### PR DESCRIPTION
**Running tests Locally**
![screenshot from 2018-01-17 12-55-16](https://user-images.githubusercontent.com/12949454/35030700-00629006-fb86-11e7-8d0a-264ce412f41c.png)

**Running tests on CI**
![download 15](https://user-images.githubusercontent.com/12949454/35030712-0e5a54fa-fb86-11e7-9879-3102bb8a4690.png)



Summary of PR builds -
- Build 1 - Success
- Build 2 - Success
- Build 3 - Failed - Jenkins Exception (`Cannot contact jenkins-slave-1sk60-fscpd: java.lang.InterruptedException`)
- Build 4 - Failed - `fabric8-ui` npm build failed (`script returned exit code -1`)
- Build 5 - Failed - chrome not reachable
- Build 6 - Success
- Build 7 - Failed - Jenkins Exception (`Could not connect to jenkins-slave-bh97n-zz54w to send interrupt signal to process`)
- Build 8 - Failed - KubernetesClientTimeoutException `io.fabric8.kubernetes.client.KubernetesClientTimeoutException: Timed out waiting for [300000] milliseconds for [Pod] with name:[jenkins-slave-1hkt1-2xmz8] in namespace [cd].`
- Build 9 - Failed - npm build failure `npm ERR! code EINTEGRITY`
- Build 10 - Failed - `Error cloning remote repo 'origin'`
- Build 11 - Failed - npm build failure `npm ERR! code EINTEGRITY`

Successful - 3
Failed - 8