### PR TITLE
fix(quickAdd): dropdown items are visible

### DIFF
--- a/src/app/components/work-item-quick-add/work-item-quick-add.component.html
+++ b/src/app/components/work-item-quick-add/work-item-quick-add.component.html
@@ -25,7 +25,7 @@
           role="menu"
           aria-labelledby="dropdownKebab"
           *dropdownMenu>
-          <li *ngFor="let type of availableTypes"
+          <li *ngFor="let type of allowedWITs"
               role="menuitem"
               (click)="selectType($event, type)">
             <a class="dropdown-item" href="#">


### PR DESCRIPTION
OSIO issue [1808](https://openshift.io/openshiftio/openshiftio/plan/detail/1808)

fix:
Dropdown items in quick add are visible now