### PR TITLE
fix(url-pattern): Introduces consistent url patterns for queries (OSIO-1780)

### DIFF
--- a/src/app/components/planner-list/planner-list.component.ts
+++ b/src/app/components/planner-list/planner-list.component.ts
@@ -289,12 +289,7 @@ export class PlannerListComponent implements OnInit, AfterViewChecked, OnDestroy
           //Join type and space query
           const first_join = this.filterService.queryJoiner({}, this.filterService.and_notation, space_query );
           const second_join = this.filterService.queryJoiner(first_join, this.filterService.and_notation, type_query );
-          //const view_query = this.filterService.queryBuilder('tree-view', this.filterService.equal_notation, 'true');
-          //const third_join = this.filterService.queryJoiner(second_join);
-          //second_join gives json object
           let query = this.filterService.jsonToQuery(second_join);
-          console.log('query is ', query);
-          // { queryParams : {q: query}
           this.router.navigate([], {
             relativeTo: this.route,
             queryParams: { q: query }
@@ -358,6 +353,9 @@ export class PlannerListComponent implements OnInit, AfterViewChecked, OnDestroy
             this.datatableWorkitems = [];
           }
         });
+        this.filterService.getFilters().subscribe(filters =>
+          filters.forEach(f => this.filters.push(f.attributes.key))
+        );
   }
 
   getCurrentGroupType() {
@@ -417,50 +415,36 @@ export class PlannerListComponent implements OnInit, AfterViewChecked, OnDestroy
       this.getCurrentGroupType();
       //set the context for the quick add based on which type group is selected
       this.quickAddContext = this.groupTypesService.getCurrentGroupType();
-      // If there is an iteration filter on the URL
-      // const queryParams = this.route.snapshot.queryParams;
-      // if (Object.keys(queryParams).indexOf('iteration') > -1) {
-      //   const iteration = iterations.find(it => {
-      //     return it.attributes.resolved_parent_path + '/' + it.attributes.name
-      //       === queryParams['iteration'];
-      //   })
-      //   if (iteration) {
-      //     this.filterService.setFilterValues('iteration', iteration.id);
-      //   }
-      // } else {
-      //   this.filterService.clearFilters(['iteration']);
-      // }
     })
       .switchMap((items) => {
-        let appliedFilters = this.filterService.getAppliedFilters();
+        let appliedFilters = this.filterService.getAppliedFilters(true);
         // remove the filter item from the filters
         for (let f = 0; f < appliedFilters.length; f++) {
           if (appliedFilters[f].paramKey == 'filter[parentexists]') {
             appliedFilters.splice(f, 1);
           }
         }
-        // KNOWN ISSUE: if the tree is expanded when switching the mode, the user will experience
-        // some weird issues. Problem is there seems to be no way of force-collapsing the tree yet.
-        // TODO: collapse the tree here so it does not give weird effects when switching modes
-        // if (this.showHierarchyList) {
-        //   // we want to display the hierarchy, so filter out all items that are childs (have no parent)
-        //   // to do this, we need to append a filter: /spaces/{id}/workitems?filter[parentexists]=false
-        //   appliedFilters.push({ id: 'parentexists', paramKey: 'filter[parentexists]', value: 'false' });
-        // }
         this.logger.log('Requesting work items with filters: ' + JSON.stringify(appliedFilters));
-
-        // TODO Filter temp
-        // Take all the applied filters and prepare an object to make the query string
         let newFilterObj = {};
         appliedFilters.forEach(item => {
           newFilterObj[item.id] = item.value;
-        })
-        newFilterObj['space'] = this.currentSpace.id;
+        });
         let payload = {};
         if (this.route.snapshot.queryParams['q']) {
-          let existingQuery = this.filterService.queryToJson(this.route.snapshot.queryParams['q']);
-          let filterQuery = this.filterService.queryToJson(this.filterService.constructQueryURL('', newFilterObj));
-          let exp = this.filterService.queryJoiner(existingQuery, this.filterService.and_notation, filterQuery);
+          let urlString = this.route.snapshot.queryParams['q']
+            .replace(' ','')
+            .replace('$AND',' ')
+            .replace('$OR',' ')
+            .replace('(','')
+            .replace(')','');
+          let temp_arr = urlString.split(' ');
+          for(let i = 0; i < temp_arr.length; i++) {
+            let arr = temp_arr[i].split(':')
+            //check if it belongs in filter array
+            if (this.filters.indexOf(arr[0]) < 0 && arr[1] !== undefined)
+              newFilterObj[arr[0]] = arr[1];
+          }
+          let exp = this.filterService.queryToJson(this.filterService.constructQueryURL('', newFilterObj));
           exp['$OPTS'] = {'tree-view': true};
           Object.assign(payload, {
             expression: exp

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -64,7 +64,7 @@ export class FilterService {
 
   setFilterValues(id, value): void {
     let index = this.activeFilters.findIndex(f => f.id === id);
-    if (index > -1) {
+    if (index > -1 && value !== undefined) {
       this.activeFilters[index].paramKey = 'filter[' + id + ']';
       this.activeFilters[index].value = value;
     } else {
@@ -115,19 +115,23 @@ export class FilterService {
       let temp_arr = urlString.split(' ');
       for(let i = 0; i < temp_arr.length; i++) {
         let arr = temp_arr[i].split(':')
-        refCurrentFilter.push({
-          id: arr[0],
-          paramKey: 'filter[' + arr[0] + ']',
-          value: arr[1]
-        })
+        if (arr[1] !== undefined ) {
+          refCurrentFilter.push({
+            id: arr[0],
+            paramKey: 'filter[' + arr[0] + ']',
+            value: arr[1]
+          })
+        }
       };
     }
-    return refCurrentFilter;
+    //active filter will have the transient filters
+    //witgroup and space are permanent filters
+    return refCurrentFilter.filter(f => f.id === '$WITGROUP' || f.id === 'space' || f.id === 'iteration');
   }
 
   clearFilters(keys: string[] = []): void {
     if (keys.length) {
-      this.activeFilters = this.activeFilters.filter(f => keys.indexOf(f.id) === -1)
+      this.activeFilters = this.activeFilters.filter(f => keys.indexOf(f.id) > -1)
     } else {
       this.activeFilters = [];
     }
@@ -155,6 +159,10 @@ export class FilterService {
         return Observable.of([] as FilterModel[]);
       }
     });
+  }
+
+  returnFilters() {
+      return this.filters
   }
 
   /**


### PR DESCRIPTION
Consistent URL patterns for queries [OSIO-1780](https://openshift.io/openshiftio/openshiftio/plan/detail/1780)
On the current UI, when we apply filters via the drop down menu, the URL looks like https://openshift.io/openshiftio/openshiftio/plan?q=(space:020f756e-b51a-4b43-b113-45cec16b9ce9%20$AND%20$WITGROUP:Scenarios)&assignee=nmukherj%20(me)
assignee is appended outside the ().

With this story, we would get something like https://openshift.io/openshiftio/openshiftio/plan?q=(space:020f756e-b51a-4b43-b113-45cec16b9ce9%20$AND%20$WITGROUP:Scenarios%20$AND%20assignee=nmukherj)