### PR TITLE
fix(CI/CD): separate out release from build step

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -205,6 +205,7 @@ gulp.task('clean', function (done) {
 
 // Release
 gulp.task('release', function (done) {
+  gulp.src(['.git/**/*']).pipe(gulp.dest('dist/.git'));
   proc.exec('$(npm bin)/semantic-release', function(error, stdout) {
     console.log("error: ", error);
     console.log(stdout);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,22 +102,12 @@ mach.transpileLESS = function (src, debug) {
 gulp.task('build', function (done) {
 
   // app (default)
-  if (!argv.release) { // @TODO: separate release from build step, maybe with `gulp release`
-    mach.transpileTS(); // Transpile *.ts to *.js; _then_ post-process require statements to load templates
-    mach.transpileLESS(appSrc + '/**/*.less'); // Transpile and minify less, storing results in distPath.
-    mach.copyToDist(['src/**/*.html']); // Copy template html files to distPath
-    gulp.src(['LICENSE', 'README.adoc', 'package.json']).pipe(gulp.dest(distPath)); // Copy static assets to distPath
-  }
+  mach.transpileTS(); // Transpile *.ts to *.js; _then_ post-process require statements to load templates
+  mach.transpileLESS(appSrc + '/**/*.less'); // Transpile and minify less, storing results in distPath.
+  mach.copyToDist(['src/**/*.html']); // Copy template html files to distPath
+  gulp.src(['LICENSE', 'README.adoc', 'package.json']).pipe(gulp.dest(distPath)); // Copy static assets to distPath
 
   // image
-
-  // release
-  if (argv.release) {
-    proc.exec('$(npm bin)/semantic-release', function(error, stdout) {
-      console.log("error: ", error);
-      console.log(stdout);
-    });
-  }
 
   // tarball
 
@@ -209,6 +199,16 @@ gulp.task('clean', function (done) {
 
   // temp
   if (argv.temp) del(['tmp', 'coverage', 'typings', '.sass-cache']);
+
+  done();
+});
+
+// Release
+gulp.task('release', function (done) {
+  proc.exec('$(npm bin)/semantic-release', function(error, stdout) {
+    console.log("error: ", error);
+    console.log(stdout);
+  });
 
   done();
 });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "gulp build",
     "clean": "gulp clean",
     "tests": "gulp tests",
-    "semantic-release": "npm run build -- --release"
+    "semantic-release": "gulp release"
   },
   "license": "Apache-2.0",
   "contributors": [


### PR DESCRIPTION
Closes #2460 

Assuming, the issue was being persistent because of npm force cleaning up `dist` if the `release` subtask was part of `build` task. So, moved `release` out to it's own task. Hopefully this resolves the issue.