### PR TITLE
fix(search): replace with typegroup.name

### DIFF
--- a/runtime/src/tests/work-item/work-item-list/workItemTypeGroup.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/workItemTypeGroup.spec.js
@@ -115,18 +115,18 @@ describe('Type group tests', function () {
   });
   */
 
-  it("Url should contain query WITGROUP:Scenario on clicking Scenario", function() {
+  it("Url should contain query typegroup.name:Scenario on clicking Scenario", function() {
     page.clickScenario();    
-    expect(browser.getCurrentUrl()).toContain('WITGROUP:Scenarios');  
+    expect(browser.getCurrentUrl()).toContain('typegroup.name:Scenarios');  
   });
 
-  it("Url should contain query WITGROUP:Experiences on clicking Experience", function() {
+  it("Url should contain query typegroup.name:Experiences on clicking Experience", function() {
     page.clickExperience();    
-    expect(browser.getCurrentUrl()).toContain('WITGROUP:Experiences');  
+    expect(browser.getCurrentUrl()).toContain('typegroup.name:Experiences');  
   });
 
-  it("Url should contain query WITGROUP:Requirements on clicking Requirements", function() {
+  it("Url should contain query typegroup.name:Requirements on clicking Requirements", function() {
     page.clickRequirements();    
-    expect(browser.getCurrentUrl()).toContain('WITGROUP:Requirements');  
+    expect(browser.getCurrentUrl()).toContain('typegroup.name:Requirements');  
   });
 });

--- a/runtime/src/tests/work-item/work-item-list/workItemTypeGroup.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/workItemTypeGroup.spec.js
@@ -115,12 +115,12 @@ describe('Type group tests', function () {
   });
   */
 
-  it("Url should contain query typegroup.name:Scenario on clicking Scenario", function() {
+  it("Url should contain query typegroup.name:Scenarios on clicking Scenarios", function() {
     page.clickScenario();    
     expect(browser.getCurrentUrl()).toContain('typegroup.name:Scenarios');  
   });
 
-  it("Url should contain query typegroup.name:Experiences on clicking Experience", function() {
+  it("Url should contain query typegroup.name:Experiences on clicking Experiences", function() {
     page.clickExperience();    
     expect(browser.getCurrentUrl()).toContain('typegroup.name:Experiences');  
   });

--- a/src/app/components/group-types-panel/group-types-panel.component.ts
+++ b/src/app/components/group-types-panel/group-types-panel.component.ts
@@ -68,7 +68,7 @@ export class GroupTypesComponent implements OnInit, OnDestroy {
 
   fnBuildQueryParam(witGroup) {
     //Query for work item type group
-    const type_query = this.filterService.queryBuilder('$WITGROUP', this.filterService.equal_notation, witGroup.attributes.name);
+    const type_query = this.filterService.queryBuilder('typegroup.name', this.filterService.equal_notation, witGroup.attributes.name);
     //Query for space
     const space_query = this.filterService.queryBuilder('space',this.filterService.equal_notation, this.spaceId);
     //Join type and space query

--- a/src/app/components/iteration-list-entry/iteration-list-entry.component.ts
+++ b/src/app/components/iteration-list-entry/iteration-list-entry.component.ts
@@ -85,7 +85,7 @@ export class IterationListEntryComponent implements OnInit, OnDestroy {
 
   constructURL(iterationId: string) {
     //Query for work item type group
-    const type_query = this.filterService.queryBuilder('$WITGROUP', this.filterService.equal_notation, this.witGroup);
+    const type_query = this.filterService.queryBuilder('typegroup.name', this.filterService.equal_notation, this.witGroup);
     //Query for space
     const space_query = this.filterService.queryBuilder('space',this.filterService.equal_notation, this.spaceId);
     //Query for iteration

--- a/src/app/components/iterations-panel/iterations-panel.component.ts
+++ b/src/app/components/iterations-panel/iterations-panel.component.ts
@@ -113,7 +113,7 @@ export class IterationComponent implements OnInit, OnDestroy, OnChanges {
 
   constructURL(iterationId: string) {
     //Query for work item type group
-    const type_query = this.filterService.queryBuilder('$WITGROUP', this.filterService.equal_notation, this.witGroup);
+    const type_query = this.filterService.queryBuilder('typegroup.name', this.filterService.equal_notation, this.witGroup);
     //Query for space
     const space_query = this.filterService.queryBuilder('space',this.filterService.equal_notation, this.spaceId);
     //Query for iteration

--- a/src/app/components/planner-list/planner-list.component.ts
+++ b/src/app/components/planner-list/planner-list.component.ts
@@ -285,7 +285,7 @@ export class PlannerListComponent implements OnInit, AfterViewChecked, OnDestroy
           const defaultGroupName = groupTypes[0].attributes.name;
           this.groupTypesService.setCurrentGroupType(groupTypes[0].relationships.typeList, groupTypes[0].attributes.bucket);
           //Query for work item type group
-          const type_query = this.filterService.queryBuilder('$WITGROUP', this.filterService.equal_notation, defaultGroupName);
+          const type_query = this.filterService.queryBuilder('typegroup.name', this.filterService.equal_notation, defaultGroupName);
           //Query for space
           const space_query = this.filterService.queryBuilder('space',this.filterService.equal_notation, spaceId);
           //Join type and space query
@@ -363,7 +363,7 @@ export class PlannerListComponent implements OnInit, AfterViewChecked, OnDestroy
   getCurrentGroupType() {
     //if initialGroup is undefined, the page has been refreshed - find  group context based on URL
     if ( this.route.snapshot.queryParams['q'] ) {
-      let urlArray = this.route.snapshot.queryParams['q'].split('WITGROUP:');
+      let urlArray = this.route.snapshot.queryParams['q'].split('typegroup.name:');
       if (urlArray.length > 1 ) {
         //If wit group is one of the parameters
         let ind = urlArray[1].indexOf(' $AND ');

--- a/src/app/components/toolbar-panel/toolbar-panel.component.ts
+++ b/src/app/components/toolbar-panel/toolbar-panel.component.ts
@@ -586,7 +586,7 @@ export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnDestroy {
         if(arr[1] !== undefined) {
           if (ref_arr.indexOf(arr[0]) >= 0)
             this.transientFilters[arr[0]] = arr[1];
-          else if (arr[0] === '$WITGROUP' || arr[0] === 'space' || arr[0] === 'iteration')
+          else if (arr[0] === 'typegroup.name' || arr[0] === 'space' || arr[0] === 'iteration')
             this.permanentFilters[arr[0]] = arr[1];
         }
       }

--- a/src/app/components_ngrx/group-types-panel/group-types-panel.component.ts
+++ b/src/app/components_ngrx/group-types-panel/group-types-panel.component.ts
@@ -76,7 +76,7 @@ export class GroupTypesComponent implements OnInit, OnDestroy {
   fnBuildQueryParam(witGroup) {
     //Query for work item type group
     const type_query = this.filterService.queryBuilder(
-      '$WITGROUP', this.filterService.equal_notation, witGroup.name
+      'typegroup.name', this.filterService.equal_notation, witGroup.name
     );
     //Query for space
     const space_query = this.filterService.queryBuilder(
@@ -100,7 +100,7 @@ export class GroupTypesComponent implements OnInit, OnDestroy {
       this.route.queryParams.subscribe(val => {
         if (val.hasOwnProperty('q')) {
           const selectedTypeGroupName =
-            this.filterService.getConditionFromQuery(val.q, '$WITGROUP');
+            this.filterService.getConditionFromQuery(val.q, 'typegroup.name');
           const selectedTypeGroup =
             this.groupTypes.find(g => g.name === selectedTypeGroupName);
           if (!selectedTypeGroup.selected) {

--- a/src/app/components_ngrx/iteration-list-entry/iteration-list-entry.component.ts
+++ b/src/app/components_ngrx/iteration-list-entry/iteration-list-entry.component.ts
@@ -84,7 +84,7 @@ export class IterationListEntryComponent implements OnInit, OnDestroy {
 
   constructURL(iterationId: string) {
     //Query for work item type group
-    const type_query = this.filterService.queryBuilder('$WITGROUP', this.filterService.equal_notation, this.witGroup);
+    const type_query = this.filterService.queryBuilder('typegroup.name', this.filterService.equal_notation, this.witGroup);
     //Query for space
     const space_query = this.filterService.queryBuilder('space',this.filterService.equal_notation, this.spaceId);
     //Query for iteration

--- a/src/app/components_ngrx/iterations-panel/iterations-panel.component.ts
+++ b/src/app/components_ngrx/iterations-panel/iterations-panel.component.ts
@@ -121,7 +121,7 @@ export class IterationComponent implements OnInit, OnDestroy, OnChanges {
 
   constructURL(iterationId: string) {
     //Query for work item type group
-    const type_query = this.filterService.queryBuilder('$WITGROUP', this.filterService.equal_notation, this.witGroup);
+    const type_query = this.filterService.queryBuilder('typegroup.name', this.filterService.equal_notation, this.witGroup);
     //Query for space
     const space_query = this.filterService.queryBuilder('space',this.filterService.equal_notation, this.spaceId);
     //Query for iteration

--- a/src/app/components_ngrx/planner-list/planner-list.component.ts
+++ b/src/app/components_ngrx/planner-list/planner-list.component.ts
@@ -339,7 +339,7 @@ export class PlannerListComponent implements OnInit, OnDestroy, AfterViewChecked
             .subscribe(groupTypes => {
               const defaultGroupName = groupTypes[0].name;
               //Query for work item type group
-              const type_query = this.filterService.queryBuilder('$WITGROUP', this.filterService.equal_notation, defaultGroupName);
+              const type_query = this.filterService.queryBuilder('typegroup.name', this.filterService.equal_notation, defaultGroupName);
               //Query for space
               const space_query = this.filterService.queryBuilder('space',this.filterService.equal_notation, spaceId);
               //Join type and space query

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -126,7 +126,7 @@ export class FilterService {
     }
     //active filter will have the transient filters
     //witgroup and space are permanent filters
-    return refCurrentFilter.filter(f => f.id === '$WITGROUP' || f.id === 'space' || f.id === 'iteration');
+    return refCurrentFilter.filter(f => f.id === 'typegroup.name' || f.id === 'space' || f.id === 'iteration');
   }
 
   clearFilters(keys: string[] = []): void {

--- a/src/app/services/work-item.service.ts
+++ b/src/app/services/work-item.service.ts
@@ -183,7 +183,7 @@ export class WorkItemService {
     if (this._currentSpace) {
       let url = '';
       if (process.env.ENV === 'inmemory') {
-        url = 'http://mock.service/api/spaces/space-id0/workitems?page[limit]=42&filter[space]=space-id0&filter[$WITGROUP]=Scenarios';
+        url = 'http://mock.service/api/spaces/space-id0/workitems?page[limit]=42&filter[space]=space-id0&filter[typegroup.name]=Scenarios';
       } else {
         this.workItemUrl = this._currentSpace.links.self.split('spaces')[0] + 'search';
         url = this.workItemUrl + '?page[limit]=' + pageSize + '&' + Object.keys(filters).map(k => 'filter['+k+']='+JSON.stringify(filters[k])).join('&');


### PR DESCRIPTION
Once the backend merges this PR: https://github.com/fabric8-services/fabric8-wit/pull/1929, the correct field to ask for when searching for type groups is `typegroup.name` and not `$WITGROUP`.