### PR TITLE
fix(filter): clear all filter option added to the active filter toolbar

### DIFF
--- a/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.html
+++ b/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.html
@@ -21,6 +21,9 @@
         </span>
       </li>
     </ul>
+    <span *ngIf="activeFilters.length > 1" class="clickable">
+      <a (click)="removeAllFilters()">Clear all filters</a>
+    </span>
   </div>
   <span *ngIf="activeFilterFromSidePane !== ''">
     <strong>14</strong> in {{activeFilterFromSidePanel}}

--- a/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.less
+++ b/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.less
@@ -86,10 +86,10 @@
         padding-left: 5px;
         padding-right: 5px;
         list-style: none;
-        .clickable {
-          cursor: pointer;
-        }
       }
+    }
+    .clickable {
+      cursor: pointer;
     }
     .label {
       font-size: 11px;

--- a/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.ts
+++ b/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.ts
@@ -535,6 +535,25 @@ export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnDestroy {
     });
   }
 
+  removeAllFilters() {
+    const fields = this.filterService.queryToFlat(
+      this.currentQuery
+    ).filter(f => {
+      return this.activeFilters.findIndex(
+        af => af.field === f.field && af.value === f.value
+      ) === -1;
+    });
+    const queryString = this.filterService.jsonToQuery(
+      this.filterService.flatToQuery(fields)
+    );
+    let queryParams = cloneDeep(this.route.snapshot.queryParams);
+    queryParams['q'] = queryString;
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: queryParams
+    });
+  }
+
   showTreeToggle(e) {
     let queryParams = cloneDeep(this.route.snapshot.queryParams);
     if (e.target.checked) {


### PR DESCRIPTION
This PR fixes following issue 
https://github.com/openshiftio/openshift.io/issues/2450

**Feature:** After adding more than one filter it shows an option to clear all filters together.