### PR TITLE
feat(docs):add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!-- Please update/review the following before submitting the PR -->
+
+### [ ] What does this PR do? _[Mandatory]_
+<!-- Description of the changes this PR brings -->
+
+### [ ] What issue/task does this PR references? _[Mandatory]_
+<!-- Provide a reference to the issue/task this PR addresses -->
+
+### [ ] Are the tests Included? _[Mandatory]_
+<!-- The PR must include tests, if applicable. MANDATORY -->
+
+#### [ ] Is the documentation Included?
+<!-- The PR **must** include documentation, if applicable -->
+
+#### [ ] Are the Release Notes included?
+<!-- For inclusion in marketing announcement - N/A for bugs. -->
+<!-- A brief two line documentation of the functionality added/improved -->
+
+#### [ ] Is/Are the @mention(s) to reviewer(s) included
+<!-- Mention the people who should review this PR -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 <!-- Please update/review the following before submitting the PR -->
 
 ### [ ] What does this PR do? _[Mandatory]_
+_Note: If you are still working on the changes, prefix the PR title with "WIP" and add the label "DO NOT MERGE"_
 <!-- Description of the changes this PR brings -->
 
 ### [ ] What issue/task does this PR references? _[Mandatory]_


### PR DESCRIPTION
Added a new PR template that reminds the PR author to provide minimum information required from documentation and review perspective.