### PR TITLE
patternfly-ng: import individual modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ngx-login-client": "^1.2.0",
     "ngx-modal": "^0.0.29",
     "ngx-widgets": "^2.3.2",
-    "patternfly-ng": "^0.13.5",
+    "patternfly-ng": "^3.1.3",
     "reflect-metadata": "^0.1.10",
     "rh-ngx-datatable": "12.0.11",
     "rxjs": "^5.0.1",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -70,7 +70,7 @@
     "ngx-login-client": "1.2.0",
     "ngx-modal": "0.0.29",
     "ngx-widgets": "2.3.1",
-    "patternfly-ng": "0.13.7",
+    "patternfly-ng": "3.1.3",
     "reflect-metadata": "0.1.10",
     "rxjs": "5.5.2",
     "zone.js": "0.8.18",

--- a/runtime/src/vendor.ts
+++ b/runtime/src/vendor.ts
@@ -18,3 +18,4 @@ import 'rxjs';
 // You can import js, ts, css, less, ...
 import 'patternfly/dist/less/patternfly.less';
 import 'patternfly/dist/less/patternfly-additions.less';
+import 'patternfly-ng/dist/less/patternfly-ng.less';

--- a/src/app/components/iterations-panel/iterations-panel.module.ts
+++ b/src/app/components/iterations-panel/iterations-panel.module.ts
@@ -9,7 +9,6 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import {
   WidgetsModule
 } from 'ngx-widgets';
-import { ActionModule, ListModule } from 'patternfly-ng';
 import { DragulaModule } from 'ng2-dragula';
 import { FabPlannerIterationModalComponent } from '../iterations-modal/iterations-modal.component';
 import { MyDatePickerModule } from 'mydatepicker';
@@ -24,7 +23,6 @@ import { TruncateModule } from 'ng2-truncate';
 
 @NgModule({
   imports: [
-    ActionModule,
     BsDropdownModule.forRoot(),
     CollapseModule,
     CommonModule,
@@ -32,7 +30,6 @@ import { TruncateModule } from 'ng2-truncate';
     FormsModule,
     MyDatePickerModule,
     ModalModule,
-    ListModule,
     TooltipModule.forRoot(),
     TruncateModule,
     SwitchModule,

--- a/src/app/components/planner-list/planner-list.component.ts
+++ b/src/app/components/planner-list/planner-list.component.ts
@@ -45,7 +45,7 @@ import {
 } from 'ngx-login-client';
 import { Space, Spaces } from 'ngx-fabric8-wit';
 
-import { EmptyStateConfig } from 'patternfly-ng';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state';
 
 // import for column
 import { datatableColumn } from './datatable-config';

--- a/src/app/components/planner-list/planner-list.module.ts
+++ b/src/app/components/planner-list/planner-list.module.ts
@@ -22,7 +22,7 @@ import { NgxDatatableModule } from 'rh-ngx-datatable';
 
 import { FilterColumn } from '../../pipes/column-filter.pipe';
 
-import { ActionModule, ListModule, EmptyStateModule } from 'patternfly-ng';
+import { EmptyStateModule } from 'patternfly-ng/empty-state';
 import { Logger } from 'ngx-base';
 import { AuthenticationService } from 'ngx-login-client';
 
@@ -105,7 +105,6 @@ if (process.env.ENV == 'inmemory') {
 
 @NgModule({
   imports: [
-    ActionModule,
     AlmIconModule,
     AssigneesModule,
     BsDropdownModule.forRoot(),
@@ -118,7 +117,6 @@ if (process.env.ENV == 'inmemory') {
     GroupTypesModule,
     IterationModule,
     LabelsModule,
-    ListModule,
     ModalModule,
     PlannerLayoutModule,
     PlannerListRoutingModule,

--- a/src/app/components/toolbar-panel/toolbar-panel.component.ts
+++ b/src/app/components/toolbar-panel/toolbar-panel.component.ts
@@ -16,11 +16,8 @@ import {
   NavigationExtras
 } from '@angular/router';
 import { cloneDeep } from 'lodash';
-import {
-  FilterConfig,
-  FilterEvent,
-  ToolbarConfig
-} from 'patternfly-ng';
+import { FilterConfig, FilterEvent } from 'patternfly-ng/filter';
+import { ToolbarConfig } from 'patternfly-ng/toolbar';
 
 import { Broadcaster } from 'ngx-base';
 import { Spaces } from 'ngx-fabric8-wit';

--- a/src/app/components/toolbar-panel/toolbar-panel.module.ts
+++ b/src/app/components/toolbar-panel/toolbar-panel.module.ts
@@ -4,7 +4,7 @@ import { NgModule } from '@angular/core';
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 
-import { ToolbarModule } from 'patternfly-ng';
+import { ToolbarModule } from 'patternfly-ng/toolbar';
 
 import { CollaboratorService } from '../../services/collaborator.service';
 import { EventService } from './../../services/event.service';

--- a/src/app/components_ngrx/iterations-panel/iterations-panel.component.ts
+++ b/src/app/components_ngrx/iterations-panel/iterations-panel.component.ts
@@ -17,14 +17,6 @@ import { FilterService } from './../../services/filter.service';
 import { IterationUI } from '../../models/iteration.model';
 import { WorkItem } from '../../models/work-item';
 import { FabPlannerIterationModalComponent } from '../iterations-modal/iterations-modal.component';
-import {
-  Action,
-  EmptyStateConfig,
-  ListBase,
-  ListEvent,
-  TreeListComponent,
-  TreeListConfig
-} from 'patternfly-ng';
 
 // ngrx stuff
 import { Store } from '@ngrx/store';

--- a/src/app/components_ngrx/iterations-panel/iterations-panel.module.ts
+++ b/src/app/components_ngrx/iterations-panel/iterations-panel.module.ts
@@ -9,7 +9,6 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import {
   WidgetsModule
 } from 'ngx-widgets';
-import { ActionModule, ListModule } from 'patternfly-ng';
 import { DragulaModule } from 'ng2-dragula';
 import { FabPlannerIterationModalComponent } from '../iterations-modal/iterations-modal.component';
 import { MyDatePickerModule } from 'mydatepicker';
@@ -29,7 +28,6 @@ import { initialUIState } from './../../states/iteration.state';
 
 @NgModule({
   imports: [
-    ActionModule,
     BsDropdownModule.forRoot(),
     CollapseModule,
     CommonModule,
@@ -37,7 +35,6 @@ import { initialUIState } from './../../states/iteration.state';
     FormsModule,
     MyDatePickerModule,
     ModalModule,
-    ListModule,
     TooltipModule.forRoot(),
     TruncateModule,
     SwitchModule,

--- a/src/app/components_ngrx/planner-list/planner-list.component.ts
+++ b/src/app/components_ngrx/planner-list/planner-list.component.ts
@@ -23,7 +23,7 @@ import { IterationUI } from './../../models/iteration.model';
 import { FilterService } from './../../services/filter.service';
 import { CookieService } from './../../services/cookie.service';
 import { cloneDeep, sortBy, isEqual } from 'lodash';
-import { EmptyStateConfig } from 'patternfly-ng';
+import { EmptyStateConfig } from 'patternfly-ng/empty-state';
 
 // import for column
 import { datatableColumn } from './../../components/planner-list/datatable-config';

--- a/src/app/components_ngrx/planner-list/planner-list.module.ts
+++ b/src/app/components_ngrx/planner-list/planner-list.module.ts
@@ -48,7 +48,7 @@ import * as effects from './../../effects/index.effects';
 import { WorkItemReducer } from './../../reducers/work-item.reducer';
 
 import { AlmIconModule } from 'ngx-widgets';
-import { EmptyStateModule } from 'patternfly-ng';
+import { EmptyStateModule } from 'patternfly-ng/empty-state';
 import { UrlService } from '../../services/url.service';
 
 let providers = [];

--- a/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.ts
+++ b/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.ts
@@ -17,11 +17,8 @@ import {
   NavigationExtras
 } from '@angular/router';
 import { cloneDeep } from 'lodash';
-import {
-  FilterConfig,
-  FilterEvent,
-  ToolbarConfig
-} from 'patternfly-ng';
+import { FilterConfig, FilterEvent } from 'patternfly-ng/filter';
+import { ToolbarConfig } from 'patternfly-ng/toolbar';
 
 import { Spaces } from 'ngx-fabric8-wit';
 import {

--- a/src/app/components_ngrx/toolbar-panel/toolbar-panel.module.ts
+++ b/src/app/components_ngrx/toolbar-panel/toolbar-panel.module.ts
@@ -4,7 +4,7 @@ import { NgModule } from '@angular/core';
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TooltipConfig, TooltipModule } from 'ngx-bootstrap/tooltip';
 
-import { ToolbarModule } from 'patternfly-ng';
+import { ToolbarModule } from 'patternfly-ng/toolbar';
 
 import { CollaboratorService } from '../../services/collaborator.service';
 import { EventService } from './../../services/event.service';


### PR DESCRIPTION
### [ ] What does this PR do? _[Mandatory]_
- This change takes advantage of patternfly-ng's individual modules so fabric8-planner imports only what’s used in the UI.
- Removes unused patternfly-ng imports referencing ListModule and ActionModule
- Updates patternfly-ng to the latest version, matching the version used by fabric8-ui

### [ ] What issue/task does this PR references? _[Mandatory]_
https://github.com/openshiftio/openshift.io/issues/2704
