### PR TITLE
fix(cicd): Use the master version of pipeline library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('github.com/fabric8io/fabric8-pipeline-library@chmod')
+@Library('github.com/fabric8io/fabric8-pipeline-library@master')
 def utils = new io.fabric8.Utils()
 def flow = new io.fabric8.Fabric8Commands()
 def project = 'fabric8-ui/fabric8-planner'


### PR DESCRIPTION
Revert "fix(cicd): Use a development branch from pipeline library (#2513)"

This reverts commit 0abb8469ae114b4c08eec91ce7405f7ad5060aa4.

There is no need to use the branch anymore since we fixed in on master. 

Ref: https://github.com/fabric8io/fabric8-pipeline-library/pull/395
