### PR TITLE
CICO: Remove commit hash from snapshot image tag

### DIFF
--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -111,9 +111,9 @@ image_name="${PULL_REGISTRY}/${IMAGE_REPO}:${TAG}"
 set +x
 # Pretty print the command for snapshot
 echo
-echo -e "\e[92m========= Run snapshot by running following command =========\e[0m"
-echo -e "\e[92m\e[1mdocker run -it -p 5000:8080 ${image_name}\e[0m"
-echo -e "\e[92m=============================================================\e[0m"
+echo -e "\e[92m========= Run snapshot by running following command =======================\e[0m"
+echo -e "\e[92m\e[1mdocker pull ${image_name} && docker run -it -p 5000:8080 ${image_name}\e[0m"
+echo -e "\e[92m===========================================================================\e[0m"
 
 # Show command before executing
 set -x

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -96,10 +96,7 @@ else
 fi
 
 # Build and push image
-# Use default length when not provided
-echo "${DEVSHIFT_TAG_LEN:=6}"
-VERSION_NUMBER=$(echo $GIT_COMMIT | cut -c1-${DEVSHIFT_TAG_LEN})
-TAG="SNAPSHOT-PR-${ghprbPullId}-${VERSION_NUMBER}"
+TAG="SNAPSHOT-PR-${ghprbPullId}"
 IMAGE_REPO="fabric8-ui/fabric8-planner"
 
 cd fabric8-ui-dist


### PR DESCRIPTION
This PR fixed the snapshot image tag.

Since there are limitations to what we can show via CICO success comment[0], we need to remove the commit hash from the image tag.

[0] - https://github.com/openshiftio/openshiftio-cico-jobs/blob/master/devtools-ci-index.yaml#L335