### PR TITLE
fix(iteration): reset datepicker on close modal

### DIFF
--- a/src/app/components_ngrx/iterations-modal/iterations-modal.component.html
+++ b/src/app/components_ngrx/iterations-modal/iterations-modal.component.html
@@ -2,6 +2,7 @@
   class="f8-iteration-modal"
   #createUpdateIterationDialog
   [title]="modalTitle"
+  [closeOnOutsideClick]="false"
   (onOpen)="actionOnOpen()"
   (onClose)="actionOnClose()"
   (onSubmit)="actionOnSubmit()">
@@ -54,15 +55,19 @@
         <div class="date-container padding-right-5 dib">
           <label>Start Date</label>
           <my-date-picker
+            #startmydp="mydatepicker"
             [options]="startDatePickerOptions"
             (dateChanged)="onStartDateChanged($event)"
+            (calendarToggle)="onStartCalendarToggle($event)"
             [(ngModel)]="startDate"></my-date-picker>
         </div>
         <div class="date-container padding-left-5 dib">
           <label>End Date</label>
           <my-date-picker
+            #endmydp="mydatepicker"
             [options]="endDatePickerOptions"
             (dateChanged)="onEndDateChanged($event)"
+            (calendarToggle)="onEndCalendarToggle($event)"
             [(ngModel)]="endDate"></my-date-picker>
         </div>
       </div>

--- a/src/app/components_ngrx/iterations-modal/iterations-modal.component.ts
+++ b/src/app/components_ngrx/iterations-modal/iterations-modal.component.ts
@@ -14,7 +14,7 @@ import { Subscription } from 'rxjs/Subscription';
 
 import { cloneDeep } from 'lodash';
 import * as moment from 'moment';
-import { IMyOptions, IMyDateModel } from 'mydatepicker';
+import { IMyOptions, IMyDateModel, MyDatePicker, IMySelector } from 'mydatepicker';
 import { Broadcaster } from 'ngx-base';
 
 import { IterationUI } from '../../models/iteration.model';
@@ -37,6 +37,8 @@ export class FabPlannerIterationModalComponent implements OnInit, OnDestroy, OnC
   @ViewChild('createUpdateIterationDialog') createUpdateIterationDialog: any;
   @ViewChild('iterationSearch') iterationSearch: any;
   @ViewChild('iterationList') iterationList: any;
+  @ViewChild('startmydp') startmydp: MyDatePicker;
+  @ViewChild('endmydp') endmydp: MyDatePicker;
 
   public iteration: IterationUI;
   private validationError = false;
@@ -75,10 +77,17 @@ export class FabPlannerIterationModalComponent implements OnInit, OnDestroy, OnC
     componentDisabled: false
   };
 
+  private startDateSelector: IMySelector = {
+    open: false
+  };
+
+  private endDateSelector: IMySelector = {
+    open: false
+  };
+
   constructor(
     private broadcaster: Broadcaster,
     private store: Store<AppState>) {}
-
 
   ngOnInit() {
     this.resetValues();
@@ -142,6 +151,12 @@ export class FabPlannerIterationModalComponent implements OnInit, OnDestroy, OnC
     this.iterationsValue = [];
     this.startDate = '';
     this.endDate = '';
+    if(this.startmydp && this.startDateSelector.open) {
+      this.startmydp.openBtnClicked();
+    }
+    if(this.endmydp && this.endDateSelector.open) {
+      this.endmydp.openBtnClicked();
+    }
   }
 
   ngOnChanges() {
@@ -224,6 +239,18 @@ export class FabPlannerIterationModalComponent implements OnInit, OnDestroy, OnC
 
   actionOnClose() {
     this.resetValues();
+  }
+
+  onStartCalendarToggle(event) {
+    this.startDateSelector = {
+      open: !this.startDateSelector.open
+    };
+  }
+
+  onEndCalendarToggle(event) {
+    this.endDateSelector = {
+      open: !this.endDateSelector.open
+    }
   }
 
   onStartDateChanged(event: IMyDateModel) {


### PR DESCRIPTION
<!-- Please update/review the following before submitting the PR -->

### [ ] What does this PR do? _[Mandatory]_
_Note: If you are still working on the changes, prefix the PR title with "WIP" and add the label "DO NOT MERGE"_
<!-- Description of the changes this PR brings -->
 - Double Clicking on calendar date does not closes the iteration dialog.
 - The calendar is not visible on reopening the create iteration dialog.

### [ ] What issue/task does this PR references? _[Mandatory]_
<!-- Provide a reference to the issue/task this PR addresses -->
issue - https://github.com/openshiftio/openshift.io/issues/2651 and https://github.com/openshiftio/openshift.io/issues/2539

### [ ] Are the tests Included? _[Mandatory]_
<!-- The PR must include tests, if applicable. MANDATORY -->

#### [ ] Is the documentation Included?
<!-- The PR **must** include documentation, if applicable -->

#### [ ] Are the Release Notes included?
<!-- For inclusion in marketing announcement - N/A for bugs. -->
<!-- A brief two line documentation of the functionality added/improved -->

#### [ ] Is/Are the @mention(s) to reviewer(s) included
<!-- Mention the people who should review this PR -->
