### PR TITLE
fix(CI/CD): Fix failing chrome installation on CentOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN yum -y update && \
       python-setuptools xorg-x11-xauth wget unzip which gcc-c++ \
       xfonts-100dpi libXfont GConf2 \
       xorg-x11-fonts-75dpi xfonts-scalable xfonts-cyrillic \
-      ipa-gothic-fonts xorg-x11-utils xorg-x11-fonts-Type1 xorg-x11-fonts-misc && \
+      ipa-gothic-fonts xorg-x11-utils xorg-x11-fonts-Type1 xorg-x11-fonts-misc \
+      epel-release libappindicator && \
       yum -y clean all
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \


### PR DESCRIPTION
Chrome installation on CentOS based containers is failing with
```
Package: google-chrome-stable-66.0.3359.117-1.x86_64 (google-chrome)
           Requires: libappindicator3.so.1()(64bit)
```

This PR adds `epel-release` and `libappindicator` packages which will fix the error.