### PR TITLE
fix(work-item-detail): remove overflow style on component destroy

### DIFF
--- a/src/app/components_ngrx/work-item-detail/work-item-detail.component.ts
+++ b/src/app/components_ngrx/work-item-detail/work-item-detail.component.ts
@@ -150,6 +150,9 @@ export class WorkItemDetailComponent implements OnInit, OnDestroy, AfterViewChec
       this.workItemSubscriber.unsubscribe();
       this.workItemSubscriber = null;
     }
+    if(document.getElementsByTagName('body')[0].style.overflow === "hidden") {
+      document.getElementsByTagName('body')[0].removeAttribute('style');
+    }
   }
 
   ngAfterViewChecked() {


### PR DESCRIPTION
fixes: https://github.com/openshiftio/openshift.io/issues/3104

<!-- Please update/review the following before submitting the PR -->

### [x] What does this PR do? _[Mandatory]_
_Note: If you are still working on the changes, prefix the PR title with "WIP" and add the label "DO NOT MERGE"_
<!-- Description of the changes this PR brings -->

This PR removes the `style="overflow: hidden` from the `<body>` when destroying the work-item-detail.component. 

I have included a more lengthy discussion in the referenced issue, with images and gifs.

There are several components in f8-planner that when activated add a style attribute to the <body> in order to hide the scrollbars ([0] for example). In all [1][2][3] but this one case [4] , this is accompanied by a line of code that changes the overflow value from hidden to auto. However, from some basic logging I've found that these ngOnDestroy() methods aren't hit when leaving the planner page, but the ngOnDestroy() for work-item-detail.component does get called - but is missing the line of code to revert the hidden style[4]. As a potential fix, I added a check in [4] to remove the style tag if it's still set to hidden when destroying the component (this way the style would be removed from the <body>, instead of just set back to auto).

[0] https://github.com/fabric8-ui/fabric8-planner/blob/fdafb9f4007e8e0b1f0c4e7e402fefa0e374cd57/src/app/components_ngrx/work-item-detail/work-item-detail.component.ts#L164
[1] https://github.com/fabric8-ui/fabric8-planner/blob/2fa253480ccd9662d2bb57a49ef49eb4e2aa91a9/src/app/components/work-item-new-detail/work-item-new-detail.component.ts#L182
[2] https://github.com/fabric8-ui/fabric8-planner/blob/baa64f626ee018dbe62176864a120311b52b899f/src/app/components/planner-board/planner-board.component.ts#L215
[3] https://github.com/fabric8-ui/fabric8-planner/blob/baeff46638b2e460eab68ee89c9985a1202ed371/src/app/components/planner-list/planner-list.component.ts#L284
[4] https://github.com/fabric8-ui/fabric8-planner/blob/fdafb9f4007e8e0b1f0c4e7e402fefa0e374cd57/src/app/components_ngrx/work-item-detail/work-item-detail.component.ts#L147

### [x] What issue/task does this PR references? _[Mandatory]_
<!-- Provide a reference to the issue/task this PR addresses -->
https://github.com/openshiftio/openshift.io/issues/3104

### [ ] Are the tests Included? _[Mandatory]_
<!-- The PR must include tests, if applicable. MANDATORY -->

No, tests aren't included.

#### [ ] Is the documentation Included?
<!-- The PR **must** include documentation, if applicable -->

No, documentation isn't included.

#### [ ] Are the Release Notes included?
<!-- For inclusion in marketing announcement - N/A for bugs. -->
<!-- A brief two line documentation of the functionality added/improved -->

#### [ ] Is/Are the @mention(s) to reviewer(s) included
<!-- Mention the people who should review this PR -->
@SMahil 