### PR TITLE
fix(dropdown): add directive for clicking outside of an element 

### DIFF
--- a/src/app/components_ngrx/planner-list/planner-list.component.html
+++ b/src/app/components_ngrx/planner-list/planner-list.component.html
@@ -66,9 +66,9 @@
       </alm-work-item-quick-add>
     </div>
     <div class="f8-wi-list__settings f8-wi__table-config">
-      <div class="dropdown-kebab-pf pull-right dropdown margin-left-10"
+      <div (clickOut)="clickOut()" class="dropdown-kebab-pf pull-right dropdown margin-left-10"
         dropdown
-        [autoClose]="true"
+        [autoClose]="false"
         [isOpen]="isTableConfigOpen"
         (isOpenChange)="tableConfigChange($event)">
         <button class="btn btn-link dropdown-toggle" 

--- a/src/app/components_ngrx/planner-list/planner-list.component.html
+++ b/src/app/components_ngrx/planner-list/planner-list.component.html
@@ -68,7 +68,7 @@
     <div class="f8-wi-list__settings f8-wi__table-config">
       <div class="dropdown-kebab-pf pull-right dropdown margin-left-10"
         dropdown
-        [autoClose]="false"
+        [autoClose]="true"
         [isOpen]="isTableConfigOpen"
         (isOpenChange)="tableConfigChange($event)">
         <button class="btn btn-link dropdown-toggle" 

--- a/src/app/components_ngrx/planner-list/planner-list.component.ts
+++ b/src/app/components_ngrx/planner-list/planner-list.component.ts
@@ -319,6 +319,11 @@ export class PlannerListComponent implements OnInit, OnDestroy, AfterViewChecked
     this.isTableConfigOpen = false;
   }
 
+  clickOut() {
+    if(this.isTableConfigOpen)
+      this.isTableConfigOpen = false;
+  }
+
   // End:  Setting(tableConfig) Dropdown
 
   togglePanelState(event) {

--- a/src/app/components_ngrx/planner-list/planner-list.module.ts
+++ b/src/app/components_ngrx/planner-list/planner-list.module.ts
@@ -51,6 +51,7 @@ import { AlmIconModule } from 'ngx-widgets';
 import { EmptyStateModule } from 'patternfly-ng/empty-state';
 import { UrlService } from '../../services/url.service';
 import { InfotipService } from '../../services/infotip.service';
+import { ClickOutModule } from '../../widgets/clickout/clickout.module';
 
 let providers = [];
 
@@ -106,6 +107,7 @@ if (process.env.ENV == 'inmemory') {
     AlmIconModule,
     AssigneesModule,
     CommonModule,
+    ClickOutModule,
     PlannerListRoutingModule,
     PlannerLayoutModule,
     PlannerModalModule,

--- a/src/app/widgets/clickout/clickout.directive.ts
+++ b/src/app/widgets/clickout/clickout.directive.ts
@@ -1,0 +1,49 @@
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Inject,
+  Input,
+  Output
+} from '@angular/core';
+
+@Directive({
+  selector: '[clickOut]'
+})
+export class ClickOutDirective {
+
+  @Input('exclude') exclude: string;
+
+  @Output('clickOut') clickOutside: EventEmitter<any> = new EventEmitter();
+
+  @HostListener('document:click', ['$event', '$event.target'])
+  onClick(event: MouseEvent, target: HTMLElement): void {
+    if (!target) {
+      return;
+    }
+
+    const clickedInside = this.element.nativeElement.contains(target);
+
+    if (this.exclude) {
+      this.isExcluded = this.excludeCheck(target);
+    }
+
+    if (!clickedInside && !this.isExcluded) {
+      this.clickOutside.emit(event);
+    }
+  }
+
+  private isExcluded: boolean = false;
+  constructor(private element: ElementRef) {
+  }
+
+  excludeCheck(target: HTMLElement) {
+    const excludeElements = Array.from(document.querySelectorAll(this.exclude)) as Array<HTMLElement>;
+    for (let element of excludeElements) {
+      if(element.contains(target)){
+        return true;
+      }
+    }
+  }
+}

--- a/src/app/widgets/clickout/clickout.module.ts
+++ b/src/app/widgets/clickout/clickout.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from "@angular/core";
+import { ClickOutDirective } from "./clickout.directive";
+
+@NgModule({
+    declarations: [ClickOutDirective],
+    exports: [ClickOutDirective]
+})
+
+export class ClickOutModule {}

--- a/src/app/widgets/select-dropdown/select-dropdown.component.html
+++ b/src/app/widgets/select-dropdown/select-dropdown.component.html
@@ -3,7 +3,7 @@
     <ng-container *ngTemplateOutlet="toggleButtonRef">
     </ng-container>
   </span>
-  <div class="select-dropdown dropdown-menu dropdown-menu-left"
+  <div (clickOut)="clickOut()" class="select-dropdown dropdown-menu dropdown-menu-left"
     [class.show]="displayDropdown">
     <div class="select-dropdown-header">
       <span> {{ headerText }} </span>

--- a/src/app/widgets/select-dropdown/select-dropdown.component.html
+++ b/src/app/widgets/select-dropdown/select-dropdown.component.html
@@ -1,9 +1,9 @@
-<div class="select-dropdown-container dropdown">
+<div (clickOut)="clickOut()" class="select-dropdown-container dropdown">
   <span (click)="openDropdown()">
     <ng-container *ngTemplateOutlet="toggleButtonRef">
     </ng-container>
   </span>
-  <div (clickOut)="clickOut()" class="select-dropdown dropdown-menu dropdown-menu-left"
+  <div class="select-dropdown dropdown-menu dropdown-menu-left"
     [class.show]="displayDropdown">
     <div class="select-dropdown-header">
       <span> {{ headerText }} </span>

--- a/src/app/widgets/select-dropdown/select-dropdown.component.ts
+++ b/src/app/widgets/select-dropdown/select-dropdown.component.ts
@@ -28,23 +28,7 @@ export class SelectDropdownComponent implements OnInit {
   @Output() onOpen: EventEmitter<any> = new EventEmitter();
   @Output() onClose: EventEmitter<any> = new EventEmitter();
 
-  @HostListener('document:click', ['$event', '$event.target']) 
-  onClick(event: MouseEvent, target: HTMLElement) :void {
-    if (this.displayDropdown) {
-      if (!target) {
-        return;
-      }
-
-      const clickedInside = this._el.nativeElement.contains(target);
-
-      if (!clickedInside) {
-        this.closeDropdown();
-      }
-    }
-  }
-
-  constructor(private _el: ElementRef) {
-
+  constructor() {
   }
 
 
@@ -68,5 +52,11 @@ export class SelectDropdownComponent implements OnInit {
 
   searchItem(text: string) {
     this.onSearch.emit(text);
+  }
+
+  clickOut() {
+    if(this.displayDropdown) {
+      this.closeDropdown();
+    }
   }
 }

--- a/src/app/widgets/select-dropdown/select-dropdown.module.ts
+++ b/src/app/widgets/select-dropdown/select-dropdown.module.ts
@@ -2,10 +2,11 @@ import { NgModule }  from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SelectDropdownComponent } from './select-dropdown.component';
 import { AlmEditableModule } from 'ngx-widgets';
+import { ClickOutModule } from '../clickout/clickout.module';
 
 @NgModule({
   declarations: [ SelectDropdownComponent ],
-  imports: [ CommonModule ],
+  imports: [ CommonModule, ClickOutModule ],
   exports: [ SelectDropdownComponent ]
 })
 export class SelectDropdownModule { }


### PR DESCRIPTION
<strong>Note: If there are pending changes to the PR, prefix the PR title with "WIP" and add the label "DO NOT MERGE"</strong>

### Mandatory
 - [ ] What does this PR do? 
- added a directive to check for outside click
- use the directive in select-dropdown
- datatable-config dropdown and quick-preview doesn't open simultaneously

- [ ] What issue/task does this PR references?
https://github.com/openshiftio/openshift.io/issues/3211

- [ ] Are the tests Included?
Tests  #2596 
___
### Optional
- [ ] Is the documentation Included?

- [ ] Are the Release Notes included?
<!-- For inclusion in marketing announcement - N/A for bugs. -->
<!-- A brief two line documentation of the functionality added/improved -->

- [ ] @mention(s) to expected reviewer(s) included
