### PR TITLE
fix(script): Update scripts used to run planner

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "gulp build",
     "clean": "gulp clean",
-    "reinstall": "rm -rf node_modules && npm  --force cache clean && npm install",
+    "reinstall": "rm -rf node_modules dist && npm --force cache clean && npm install",
     "tests": "gulp tests",
     "semantic-release": "semantic-release pre && gulp build  && npm publish dist/ && semantic-release post"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "gulp build",
     "clean": "gulp clean",
+    "reinstall": "rm -rf node_modules && npm  --force cache clean && npm install",
     "tests": "gulp tests",
     "semantic-release": "semantic-release pre && gulp build  && npm publish dist/ && semantic-release post"
   },

--- a/runtime/config/webpack.dev.js
+++ b/runtime/config/webpack.dev.js
@@ -6,15 +6,13 @@ var helpers = require('./helpers');
 // var DashboardPlugin = require('webpack-dashboard/plugin');
 
 const ENV = process.env.ENV || process.env.NODE_ENV || 'development';
-// if env is 'inmemory', the inmemory debug resource is used
-const API_URL = process.env.API_URL || (ENV === 'inmemory' ? 'app/' : 'http://localhost:8080/api/');
-const FORGE_URL = process.env.FORGE_URL || 'http://localhost:8080/forge';
-const FABRIC8_WIT_API_URL = process.env.FABRIC8_WIT_API_URL || 'http://localhost:8080/api/';
-const FABRIC8_AUTH_API_URL = process.env.FABRIC8_AUTH_API_URL || 'http://localhost:8089/api/';
+const FABRIC8_WIT_API_URL = process.env.FABRIC8_WIT_API_URL || 'https://api.prod-preview.openshift.io/api/';
+const FABRIC8_AUTH_API_URL = process.env.FABRIC8_AUTH_API_URL || 'https://auth.prod-preview.openshift.io/api/';
 const FABRIC8_SSO_API_URL = process.env.FABRIC8_SSO_API_URL || 'https://sso.prod-preview.openshift.io/';
 const FABRIC8_REALM = process.env.FABRIC8_REALM || "fabric8";
 const FABRIC8_RECOMMENDER_API_URL = process.env.FABRIC8_RECOMMENDER_API_URL;
-const FABRIC8_FORGE_URL = process.env.FABRIC8_FORGE_URL;
+const FABRIC8_FORGE_URL = process.env.FABRIC8_FORGE_URL || 'https://api.prod-preview.openshift.io/forge';
+const API_URL = FABRIC8_WIT_API_URL;
 const PUBLIC_PATH = process.env.PUBLIC_PATH || '/';
 const extractCSS = new ExtractTextPlugin('stylesheets/[name].css');
 const extractLESS = new ExtractTextPlugin('stylesheets/[name].less');
@@ -23,7 +21,6 @@ const extractLESS = new ExtractTextPlugin('stylesheets/[name].less');
 const METADATA = webpackMerge(commonConfig.metadata, {
   API_URL: API_URL,
   ENV: ENV,
-  FORGE_URL: FORGE_URL,
   FABRIC8_REALM: FABRIC8_REALM,
   FABRIC8_WIT_API_URL: FABRIC8_WIT_API_URL,
   FABRIC8_AUTH_API_URL: FABRIC8_AUTH_API_URL,

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -17,7 +17,7 @@
     "clean:dist": "npm run rimraf -- dist",
     "clean:install": "npm set progress=false && npm install",
     "clean": "npm --force cache clean && npm run rimraf -- node_modules doc coverage dist compiled dll",
-    "reinstall": "rm -rf node_modules && npm --force cache clean && npm install",
+    "reinstall": "rm -rf node_modules dist && npm --force cache clean && npm install",
     "lint": "npm run tslint \"src/**/*.ts\"",
     "postversion": "git push && git push --tags",
     "preclean:install": "npm run clean",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -17,7 +17,7 @@
     "clean:dist": "npm run rimraf -- dist",
     "clean:install": "npm set progress=false && npm install",
     "clean": "npm --force cache clean && npm run rimraf -- node_modules doc coverage dist compiled dll",
-    "reinstall": "rimraf node_modules && npm --force cache clean && npm install",
+    "reinstall": "rm -rf node_modules && npm --force cache clean && npm install",
     "lint": "npm run tslint \"src/**/*.ts\"",
     "postversion": "git push && git push --tags",
     "preclean:install": "npm run clean",

--- a/scripts/run-planner.sh
+++ b/scripts/run-planner.sh
@@ -56,7 +56,7 @@ function serveProject {
 
 function runIntegrated {
   declare buildDone=0
-  if [ $REINSTALL -eq 1]; then
+  if [ $REINSTALL -eq 1 ]; then
     reinstallPlannerAndBuild
     buildDone=1
     if [ ! -d "$PLATFORM_HOME" ]; then
@@ -67,7 +67,7 @@ function runIntegrated {
     cd $PLATFORM_HOME && npm run reinstall
   fi
 
-  if [ $buildDone -eq 0]; then
+  if [ $buildDone -eq 0 ]; then
     buildPlanner
   fi
 

--- a/scripts/run-planner.sh
+++ b/scripts/run-planner.sh
@@ -26,6 +26,8 @@ declare STANDALONE=0
 declare -r options=`getopt -o rsp:f: --long reinstall,standalone,plannerhome:,platformhome: -n 'run-planner.sh' -- "$@"`
 eval set -- "$options"
 
+trap "trap - SIGTERM && kill -- -$$" INT TERM EXIT
+
 function log {
   echo
   echo -e "\e[93m============================================================"
@@ -35,8 +37,10 @@ function log {
 
 function buildPlanner {
   log "Building Planner"
-  cd $PLANNER_HOME &&  npm run build -- --watch &
-  sleep 5
+  cd $PLANNER_HOME && npm run build -- --watch &
+  # This sleep is necessary since the build takes about 15 secs.
+  # We need to wait for the build to complete.
+  sleep 20
 }
 
 function reinstallPlannerAndBuild {

--- a/scripts/run-planner.sh
+++ b/scripts/run-planner.sh
@@ -35,7 +35,8 @@ function log {
 
 function buildPlanner {
   log "Building Planner"
-  cd $PLANNER_HOME &&  npm run build
+  cd $PLANNER_HOME &&  npm run build -- --watch &
+  sleep 5
 }
 
 function reinstallPlannerAndBuild {

--- a/scripts/run-planner.sh
+++ b/scripts/run-planner.sh
@@ -46,7 +46,7 @@ function reinstallPlannerAndBuild {
 }
 
 function linkPlannerTo {
-  log "Linking Planner to Platform in $1"
+  log "Linking Planner to $1"
   cd $1 && npm link $PLANNER_HOME/dist
 }
 

--- a/scripts/run-planner.sh
+++ b/scripts/run-planner.sh
@@ -4,7 +4,7 @@
 # It has the following commandline options:
 #
 #   -r reinstalls all needed components before launching 
-#   -s runs in standalone (non-Plaform mode) with inmemory mock data
+#   -s runs in standalone (non-Plaform mode)
 #   -p <planner_home_dir> sets the Planner home, defaults to current directory
 #   -f <platform_home_dir> sets the Platform home, defaults to <current directory>/../fabric8-ui
 #


### PR DESCRIPTION
This PR fixes
https://openshift.io/openshiftio/openshiftio/plan/detail/2277
https://openshift.io/openshiftio/openshiftio/plan/detail/2278



**How to test -**
The runner scipt supports following flags
1. `-r` - This would reinstall everything
2. `-s` - This would start planner in standalone mode (using the runtime)
3. `-p` - Set path to planner directory (requires path argument)
4. `-f` - Set path to platform directory (requires path argument)

**Run the script as**
- `scripts/run-planner.sh -r -s` - if you wish to reinstall planner and run planner in standalone mode
- `scripts/run-planner.sh -r -f /home/User/fabric8-ui` - if you wish to set the platform path. By default, the platform path is assumed to me `Planner_Path/..`

**NOTE** - Integrated mode is the default mode for running planner via this script

If you start planner in 
- `Standalone Mode` - it should be accessible at `http://localhost:8008`
- `Integrated Mode` - It should be accessible at `http://localhost:3000`

**NOTE** - The `Standalone Mode` uses prod-preview backend by default. You can change this by setiing approriate environment variables (`FABRIC8_WIT_API_URL`, `FABRIC8_AUTH_API_URL`, etc)
