### PR TITLE
fix(unit-tests): add unit tests for infotip effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "husky": "0.14.3",
     "istanbul-instrumenter-loader": "3.0.0",
     "jasmine-core": "2.8.0",
+    "jasmine-marbles": "0.2.0",
     "json-loader": "0.5.7",
     "karma": "1.7.1",
     "karma-chrome-launcher": "2.2.0",

--- a/src/app/effects/infotip.effects.spec.ts
+++ b/src/app/effects/infotip.effects.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@angular/core/testing'
+import { provideMockActions } from '@ngrx/effects/testing'
+import { hot, cold } from 'jasmine-marbles';
+
+import { InfotipEffects } from './infotip.effects';
+import { InfotipService } from '../services/infotip.service';
+import { Observable } from 'rxjs';
+import * as Actions from '../actions/infotip.actions';
+import { Action } from 'rxjs/scheduler/Action';
+import { InfotipState } from '../states/infotip.state';
+
+fdescribe('InfotipEffects', () => {
+  let effects: InfotipEffects;
+  let actions: Observable<any>;
+  let infotipService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+
+      ],
+      providers: [
+        InfotipEffects,
+        provideMockActions(() => actions),
+        {
+          provide: InfotipService,
+          useValue: jasmine.createSpyObj('infotipService', ['getInfotips'])
+        }
+      ]
+    });
+
+    effects = TestBed.get(InfotipEffects);
+    infotipService = TestBed.get(InfotipService);
+  });
+
+  beforeEach(() => {
+
+  })
+
+  it("should fetch infotips", () => {
+    let payload: InfotipState = { 
+      "6cff4ab8-c380-4aa9-9980-17b6f223d181": {
+        "term": "alternate dependency",
+        "en": "Dependencies recommended by OpenShift.io to replace restrictive licenses or usage outliers."
+      } 
+    };
+    const action = new Actions.Get();
+    const success = new Actions.GetSuccess(payload);
+    
+    infotipService.getInfotips.and.returnValue(Observable.of(payload));
+
+    actions = hot('--a-', { a: action });
+    const expected = cold('--b', { b: success });
+
+    expect(effects.getInfotips$).toBeObservable(expected);
+  });
+
+  it("should dispatch an error action", () => {
+    const action = new Actions.Get();
+    const error = new Actions.GetError();
+
+    infotipService.getInfotips.and.returnValue(Observable.throw(new Error()));
+
+    actions = hot('--a-', { a: action });
+    const expected = cold('--b', { b: error });
+
+    expect(effects.getInfotips$).toBeObservable(expected);
+  })
+});

--- a/src/app/effects/infotip.effects.spec.ts
+++ b/src/app/effects/infotip.effects.spec.ts
@@ -9,7 +9,7 @@ import * as Actions from '../actions/infotip.actions';
 import { Action } from 'rxjs/scheduler/Action';
 import { InfotipState } from '../states/infotip.state';
 
-fdescribe('InfotipEffects', () => {
+describe('InfotipEffects', () => {
   let effects: InfotipEffects;
   let actions: Observable<any>;
   let infotipService;
@@ -32,10 +32,6 @@ fdescribe('InfotipEffects', () => {
     effects = TestBed.get(InfotipEffects);
     infotipService = TestBed.get(InfotipService);
   });
-
-  beforeEach(() => {
-
-  })
 
   it("should fetch infotips", () => {
     let payload: InfotipState = { 


### PR DESCRIPTION
<strong>Note: If there are pending changes to the PR, prefix the PR title with "WIP" and add the label "DO NOT MERGE"</strong>

### Mandatory
 - [x] What does this PR do? 
 This PR adds the unit tests for infotip effects
- [ ] What issue/task does this PR references?
  https://openshift.io/openshiftio/openshiftio/plan/detail/2331
- [x] Are the tests Included?
Yes
**NOTE:** 
jasmine-marbles: https://github.com/synapse-wireless-labs/jasmine-marbles
RxJs testing using marbles: https://github.com/ReactiveX/rxjs/blob/master/doc/marble-testing.md
___
### Optional
- [ ] Is the documentation Included?

- [ ] Are the Release Notes included?
<!-- For inclusion in marketing announcement - N/A for bugs. -->
<!-- A brief two line documentation of the functionality added/improved -->

- [ ] @mention(s) to expected reviewer(s) included
