### PR TITLE
Markdown checkbox integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "ngx-fabric8-wit": "^6.20.2",
     "ngx-login-client": "^1.2.0",
     "ngx-modal": "^0.0.29",
-    "ngx-widgets": "^2.3.8",
+    "ngx-widgets": "^2.4.0",
     "patternfly-ng": "^3.1.3",
     "reflect-metadata": "^0.1.10",
     "rh-ngx-datatable": "12.0.11",

--- a/src/app/components_ngrx/work-item-comment/work-item-comment.component.html
+++ b/src/app/components_ngrx/work-item-comment/work-item-comment.component.html
@@ -94,7 +94,7 @@
                   )
                 )"
                 [rawText]="comment.body"
-                [renderedText]="comment.bodyRendered"
+                [renderedText]="comment.bodyRendered  | safe: 'html'"
                 [placeholder]="'Add a new comment...'"
                 (onSaveClick)="updateComment($event, comment)"
                 (showPreview)="showPreview($event)">

--- a/src/app/components_ngrx/work-item-comment/work-item-comment.module.ts
+++ b/src/app/components_ngrx/work-item-comment/work-item-comment.module.ts
@@ -19,6 +19,8 @@ import {
 import { WorkItemCommentComponent } from './work-item-comment.component';
 import { PlannerModalModule } from './../../components/modal/modal.module';
 
+import { SafePipe } from '../../pipes/safe.pipe';
+
 import { MockHttp } from '../../mock/mock-http';
 
 let providers = [];
@@ -64,9 +66,10 @@ if (process.env.ENV == 'inmemory') {
     WidgetsModule
   ],
   declarations: [
-    WorkItemCommentComponent
+    WorkItemCommentComponent,
+    SafePipe
    ],
-  exports: [ WorkItemCommentComponent ],
+  exports: [ WorkItemCommentComponent, SafePipe ],
   providers: providers
 })
 export class WorkItemCommentModule { }

--- a/src/app/components_ngrx/work-item-detail/work-item-detail.component.html
+++ b/src/app/components_ngrx/work-item-detail/work-item-detail.component.html
@@ -299,7 +299,7 @@
                 id="wi-desc-div"
                 [editAllow]="loggedIn"
                 [rawText]="workItem.description"
-                [renderedText]="workItem.descriptionRendered"
+                [renderedText]="workItem.descriptionRendered | safe: 'html'"
                 (onSaveClick)="descUpdate($event)"
                 (showPreview)="showPreview($event)" #descMarkdown>
               </f8-markdown>

--- a/src/app/components_ngrx/work-item-detail/work-item-detail.module.ts
+++ b/src/app/components_ngrx/work-item-detail/work-item-detail.module.ts
@@ -43,6 +43,8 @@ import { UrlService } from '../../services/url.service';
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { LabelSelectorModule } from '../label-selector/label-selector.module';
 
+import { SafePipe } from '../../pipes/safe.pipe';
+
 @NgModule({
   imports: [
     AlmUserNameModule,
@@ -90,10 +92,12 @@ import { LabelSelectorModule } from '../label-selector/label-selector.module';
     TooltipConfig
   ],
   declarations: [
-    WorkItemDetailComponent
+    WorkItemDetailComponent,
+    SafePipe
   ],
   exports: [
-    WorkItemDetailComponent
+    WorkItemDetailComponent,
+    SafePipe
   ]
 })
 export class WorkItemDetailModule {}

--- a/src/app/pipes/safe.pipe.ts
+++ b/src/app/pipes/safe.pipe.ts
@@ -1,0 +1,29 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import {
+  DomSanitizer,
+  SafeHtml,
+  SafeStyle,
+  SafeScript,
+  SafeUrl,
+  SafeResourceUrl
+} from '@angular/platform-browser';
+
+@Pipe({
+  name: 'safe'
+})
+export class SafePipe implements PipeTransform {
+
+  constructor(protected sanitizer: DomSanitizer) {}
+
+ public transform(value: any, type: string):
+  SafeHtml | SafeStyle | SafeScript | SafeUrl | SafeResourceUrl {
+    switch (type) {
+      case 'html': return this.sanitizer.bypassSecurityTrustHtml(value);
+      case 'style': return this.sanitizer.bypassSecurityTrustStyle(value);
+      case 'script': return this.sanitizer.bypassSecurityTrustScript(value);
+      case 'url': return this.sanitizer.bypassSecurityTrustUrl(value);
+      case 'resourceUrl': return this.sanitizer.bypassSecurityTrustResourceUrl(value);
+      default: throw new Error(`Invalid safe type specified: ${type}`);
+    }
+  }
+}


### PR DESCRIPTION
 - What does this PR do? 
Integrate latest changes from ngx-widgets. Namely checkbox support for Markdown fields.

- What issue/task does this PR references?
https://openshift.io/openshiftio/openshiftio/plan/detail/2019

- Are the tests Included?
No as this is only an integration update to the newest upstream library. Tests are provided upstream on ngx-widgets.