### PR TITLE
Data normalisation initial work / demonstration 

### DIFF
--- a/src/app/actions/user.actions.ts
+++ b/src/app/actions/user.actions.ts
@@ -1,15 +1,17 @@
+
 import { Action } from '@ngrx/store';
 import { UserUI } from './../models/user';
 import { UserState } from './../states/user.state';
 
 export const SET = '[users] Set';
 export const GET = '[users] Get';
+export const GET_ERROR = '[users] GetError';
 
 /**
  * This action class set the normalized user data
  * Be it one user or number of users we can use
  * this action to update the user state
- * The payload value is a disctionary of users
+ * The payload value is a dictionary of users
  * where the id is the key and value is the entire
  */
 export class Set implements Action {
@@ -32,5 +34,9 @@ export class Get implements Action {
   readonly type = GET;
 }
 
+export class GetError implements Action {
+  readonly type = GET_ERROR;
+}
+
 export type All
-  = Set | Get;
+  = Set | Get | GetError;

--- a/src/app/actions/user.actions.ts
+++ b/src/app/actions/user.actions.ts
@@ -1,0 +1,23 @@
+import { Action } from '@ngrx/store';
+import { UserUI } from './../models/user';
+import { UserState } from './../states/user.state';
+
+export const SET = '[users] Get';
+
+/**
+ * This action class set the normalized user data
+ * Be it one user or number of users we can use
+ * this action to update the user state
+ * The payload value is a disctionary of users
+ * where the id is the key and value is the entire
+ */
+export class Set implements Action {
+  payload: UserState;
+  constructor(payload: UserState) {
+    this.payload = payload;
+  }
+  readonly type = SET;
+}
+
+export type All
+  = Set

--- a/src/app/actions/user.actions.ts
+++ b/src/app/actions/user.actions.ts
@@ -2,7 +2,8 @@ import { Action } from '@ngrx/store';
 import { UserUI } from './../models/user';
 import { UserState } from './../states/user.state';
 
-export const SET = '[users] Get';
+export const SET = '[users] Set';
+export const GET = '[users] Get';
 
 /**
  * This action class set the normalized user data
@@ -19,5 +20,17 @@ export class Set implements Action {
   readonly type = SET;
 }
 
+/**
+ * This action is used to get one user
+ * from server by it's ID
+ */
+export class Get implements Action {
+  payload: string;
+  constructor(payload: string) {
+    this.payload = payload;
+  }
+  readonly type = GET;
+}
+
 export type All
-  = Set
+  = Set | Get;

--- a/src/app/components_ngrx/planner-list/planner-list.module.ts
+++ b/src/app/components_ngrx/planner-list/planner-list.module.ts
@@ -129,7 +129,8 @@ if (process.env.ENV == 'inmemory') {
         workItemTypes: reducers.WorkItemTypeReducer,
         workItems: reducers.WorkItemReducer,
         workItemStates: reducers.WorkItemStateReducer,
-        infotips: reducers.InfotipReducer
+        infotips: reducers.InfotipReducer,
+        users: reducers.UserReducer
       }, {
       initialState: {
         iterations: states.initialIterationState,
@@ -142,7 +143,8 @@ if (process.env.ENV == 'inmemory') {
         workItemTypes: states.initialWorkItemTypeState,
         workItems: states.initialWorkItemState,
         workItemStates: states.initialWIState,
-        infotips: states.initialInfotipState
+        infotips: states.initialInfotipState,
+        users: states.inititalUserState
       }
     }),
     EffectsModule.forFeature([
@@ -155,7 +157,8 @@ if (process.env.ENV == 'inmemory') {
       effects.SpaceEffects,
       effects.WorkItemTypeEffects,
       effects.WorkItemEffects,
-      effects.InfotipEffects
+      effects.InfotipEffects,
+      effects.UserEffects
     ])
   ],
   declarations: [

--- a/src/app/components_ngrx/planner-list/planner-list.module.ts
+++ b/src/app/components_ngrx/planner-list/planner-list.module.ts
@@ -52,6 +52,13 @@ import { EmptyStateModule } from 'patternfly-ng/empty-state';
 import { UrlService } from '../../services/url.service';
 import { InfotipService } from '../../services/infotip.service';
 
+// Data Resolvers and Mappers
+import { CommentMapper } from './../../models/comment';
+import {
+  UserResolver,
+  UserMapper
+} from './../../models/user';
+
 let providers = [];
 
 if (process.env.ENV == 'inmemory') {
@@ -97,7 +104,11 @@ if (process.env.ENV == 'inmemory') {
     CookieService,
     WorkItemDataService,
     UrlService,
-    InfotipService
+    InfotipService,
+
+    CommentMapper,
+    UserResolver,
+    UserMapper
   ];
 }
 

--- a/src/app/components_ngrx/planner-list/planner-list.module.ts
+++ b/src/app/components_ngrx/planner-list/planner-list.module.ts
@@ -52,12 +52,9 @@ import { EmptyStateModule } from 'patternfly-ng/empty-state';
 import { UrlService } from '../../services/url.service';
 import { InfotipService } from '../../services/infotip.service';
 
-// Data Resolvers and Mappers
-import { CommentMapper } from './../../models/comment';
-import {
-  UserResolver,
-  UserMapper
-} from './../../models/user';
+// Data Querries
+import { CommentQuery } from './../../models/comment';
+import { UserQuery } from './../../models/user';
 
 let providers = [];
 
@@ -106,9 +103,8 @@ if (process.env.ENV == 'inmemory') {
     UrlService,
     InfotipService,
 
-    CommentMapper,
-    UserResolver,
-    UserMapper
+    CommentQuery,
+    UserQuery
   ];
 }
 

--- a/src/app/components_ngrx/work-item-comment-wrapper/work-item-comment-wrapper.component.html
+++ b/src/app/components_ngrx/work-item-comment-wrapper/work-item-comment-wrapper.component.html
@@ -1,6 +1,6 @@
 <div>
     <alm-work-item-comment
-      [comments]="comments"
+      [comments]="comments | async"
       [loggedIn]="loggedIn"
       [loggedInUser]="loggedInUser"
       (create)="createComment($event)"

--- a/src/app/components_ngrx/work-item-comment-wrapper/work-item-comment-wrapper.component.ts
+++ b/src/app/components_ngrx/work-item-comment-wrapper/work-item-comment-wrapper.component.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import {
   Component,
   Input,
@@ -11,7 +12,7 @@ import { Store } from '@ngrx/store';
 import { AppState } from './../../states/app.state';
 import { WorkItemUI } from './../../models/work-item';
 import { UserUI } from './../../models/user';
-import { CommentUI } from './../../models/comment';
+import { CommentUI, CommentQuery } from './../../models/comment';
 import * as CommentActions from './../../actions/comment.actions';
 import * as CollaboratorActions from './../../actions/collaborator.actions';
 
@@ -30,38 +31,16 @@ export class WorkItemCommentWrapperComponent implements OnInit, OnDestroy {
   }
 
   private workItem: WorkItemUI = null;
-  private comments: CommentUI[] = [];
+  private comments: Observable<CommentUI[]> =
+    this.commentQuery.getCommentsWithCreators();
   private eventListeners: any[] = [];
 
-  private spaceSource = this.store
-    .select('listPage')
-    .select('space')
-    .filter(s => !!s);
-  private collaboratorSource = this.store
-    .select('listPage')
-    .select('collaborators')
-    .filter(c => !!c.length);
-  private commentSource = this.store
-    .select('detailPage')
-    .select('comments');
+  constructor(
+    private store: Store<AppState>,
+    private commentQuery: CommentQuery
+  ) {}
 
-  constructor(private store: Store<AppState>) {}
-
-  ngOnInit() {
-    Observable.combineLatest(
-      this.spaceSource,
-      this.collaboratorSource
-    ).take(1).subscribe(([
-      spaceSource,
-      collaboratorSource,
-    ]) => {
-      this.eventListeners.push(
-        this.commentSource.subscribe(comments => {
-          this.comments = [...comments];
-        })
-      )
-    })
-  }
+  ngOnInit() {}
 
   ngOnDestroy() {
     this.eventListeners.forEach(e => e.unsubscribe());

--- a/src/app/components_ngrx/work-item-comment/work-item-comment.component.html
+++ b/src/app/components_ngrx/work-item-comment/work-item-comment.component.html
@@ -40,20 +40,20 @@
     <div>
       <div class="f8-comment__wrap"
         *ngFor='let comment of comments; let counter = index'>
-        <div *ngIf="comment.creator | async as creator">
+        <div>
           <div class="user-avatar margin-right-10 pull-left">
             <img class="user-assign-avatar"
               id="{{'comment_avatar_' + counter}}"
               placement="right"
               container="body"
-              tooltip="{{creator.name}}"
-              *ngIf="creator.avatar"
-              [src]="creator.avatar | almAvatarSize:30"
+              tooltip="{{ (comment.creator | async)?.name }}"
+              *ngIf="(comment.creator | async)?.avatar"
+              [src]="(comment.creator | async)?.avatar | almAvatarSize:30"
             />
           </div>
           <div class="dropdown dropdown-kebab-pf pull-right dropdown" dropdown>
             <button class="btn btn-link dropdown-toggle"
-              *ngIf="loggedIn && (loggedInUser?.id === creator.id)"
+              *ngIf="loggedIn && (loggedInUser?.id === (comment.creator | async)?.id)"
               id="commentActionsKebab"
               type="button"
               dropdownToggle
@@ -75,7 +75,7 @@
               <h5 class="f8-comment-author pull-left">
                 <strong  class="truncate"
                   id="{{'comment_username_' + counter}}">
-                  {{creator.name}}
+                  {{(comment.creator | async)?.name}}
                 </strong>
               </h5>
               <small class="f8-comment--create-time pull-right"
@@ -90,7 +90,7 @@
                   loggedIn &&
                   (
                     commentEditable ||
-                    (loggedInUser?.id === creator.id)
+                    (loggedInUser?.id === (comment.creator | async)?.id)
                   )
                 )"
                 [rawText]="comment.body"

--- a/src/app/components_ngrx/work-item-comment/work-item-comment.component.html
+++ b/src/app/components_ngrx/work-item-comment/work-item-comment.component.html
@@ -1,4 +1,4 @@
-<div class="f8-comment" 
+<div class="f8-comment"
   id="wi-comment">
   <ul class="f8-comment-content nav nav-tabs nav-tabs-pf"
     id="wi-comment-content"
@@ -40,20 +40,20 @@
     <div>
       <div class="f8-comment__wrap"
         *ngFor='let comment of comments; let counter = index'>
-        <div>
+        <div *ngIf="comment.creator | async as creator">
           <div class="user-avatar margin-right-10 pull-left">
             <img class="user-assign-avatar"
               id="{{'comment_avatar_' + counter}}"
               placement="right"
               container="body"
-              tooltip="{{comment.creator.name}}"
-              *ngIf="comment.creator.avatar"
-              [src]="comment.creator.avatar | almAvatarSize:30"
+              tooltip="{{creator.name}}"
+              *ngIf="creator.avatar"
+              [src]="creator.avatar | almAvatarSize:30"
             />
           </div>
           <div class="dropdown dropdown-kebab-pf pull-right dropdown" dropdown>
             <button class="btn btn-link dropdown-toggle"
-              *ngIf="loggedIn && (loggedInUser?.id === comment.creator.id)"
+              *ngIf="loggedIn && (loggedInUser?.id === creator.id)"
               id="commentActionsKebab"
               type="button"
               dropdownToggle
@@ -75,7 +75,7 @@
               <h5 class="f8-comment-author pull-left">
                 <strong  class="truncate"
                   id="{{'comment_username_' + counter}}">
-                  {{comment.creator.name}}
+                  {{creator.name}}
                 </strong>
               </h5>
               <small class="f8-comment--create-time pull-right"
@@ -90,7 +90,7 @@
                   loggedIn &&
                   (
                     commentEditable ||
-                    (loggedInUser?.id === comment.creator.id)
+                    (loggedInUser?.id === creator.id)
                   )
                 )"
                 [rawText]="comment.body"

--- a/src/app/components_ngrx/work-item-detail/work-item-detail.module.ts
+++ b/src/app/components_ngrx/work-item-detail/work-item-detail.module.ts
@@ -1,3 +1,4 @@
+import { CommentQuery } from './../../models/comment';
 import { LabelsModule } from './../labels/labels.module';
 import { TypeaheadDropDownModule } from './../../components/typeahead-dropdown/typeahead-dropdown.module';
 import { AlmUserNameModule } from './../../pipes/alm-user-name.module';
@@ -8,7 +9,7 @@ import { RouterModule } from '@angular/router';
 import { InlineInputModule } from './../../widgets/inlineinput/inlineinput.module';
 import { WidgetsModule, MarkdownModule } from 'ngx-widgets';
 import { FormsModule } from '@angular/forms';
-import { UserMapper } from './../../models/user';
+import { UserMapper, UserQuery } from './../../models/user';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { WorkItemDetailComponent } from './work-item-detail.component';
@@ -83,6 +84,8 @@ import { LabelSelectorModule } from '../label-selector/label-selector.module';
     ])
   ],
   providers: [
+    CommentQuery,
+    UserQuery,
     UserMapper,
     UrlService,
     BsDropdownConfig,

--- a/src/app/effects/comment.effects.ts
+++ b/src/app/effects/comment.effects.ts
@@ -1,7 +1,6 @@
 import { Store } from '@ngrx/store';
 import { Actions, Effect } from '@ngrx/effects';
 import { Injectable } from '@angular/core';
-import { cloneDeep } from 'lodash';
 import * as CommentActions from './../actions/comment.actions';
 import { AppState } from './../states/app.state';
 import { Observable } from 'rxjs';
@@ -28,9 +27,9 @@ export class CommentEffects {
     private workItemService: WorkItemService,
     private store: Store<AppState>,
     private userMapper: UserMapper,
-    private notifications: Notifications,
-    private commentMapper: CommentMapper
+    private notifications: Notifications
   ) {}
+  private commentMapper: CommentMapper = new CommentMapper();
 
   @Effect() getWorkItemComments$: Observable<Action> = this.actions$
     .ofType<CommentActions.Get>(CommentActions.GET)

--- a/src/app/effects/index.effects.ts
+++ b/src/app/effects/index.effects.ts
@@ -13,3 +13,5 @@ export { DetailWorkItemEffects } from './detail-work-item.effects';
 export { LinkTypeEffects } from './link-type.effects';
 export { WorkItemLinkEffects } from './work-item-link.effects';
 export { InfotipEffects } from './infotip.effects';
+export { UserEffects } from './user.effects';
+

--- a/src/app/effects/user.effects.ts
+++ b/src/app/effects/user.effects.ts
@@ -44,5 +44,17 @@ export class UserEffects {
           const mappedUser: UserUI = userMapper.toUIModel(user);
           return new UserActions.Set(normalizeArray<UserUI>([mappedUser]));
         })
+    })
+    .catch(e => {
+      try {
+        this.notifications.message({
+          message: `Problem in user details`,
+          type: NotificationType.DANGER
+        } as Notification);
+      } catch (e) {
+        console.log('Problem in user details');
+      }
+      return Observable.of(new UserActions.GetError());
     });
+;
 }

--- a/src/app/effects/user.effects.ts
+++ b/src/app/effects/user.effects.ts
@@ -1,0 +1,48 @@
+import { Actions, Effect } from '@ngrx/effects';
+import { Injectable } from '@angular/core';
+import {
+  Notification,
+  Notifications,
+  NotificationType
+} from 'ngx-base';
+import { Observable } from 'rxjs';
+import { UserService } from 'ngx-login-client';
+
+import * as CollaboratorActions from './../actions/collaborator.actions';
+import * as UserActions from './../actions/user.actions';
+import {
+  UserUI,
+  UserMapper,
+  UserService as UserServiceModel
+} from './../models/user';
+import { normalizeArray } from '../models/common.model';
+
+export type CollabGetSuccess = CollaboratorActions.GetSuccess;
+export type UserAction = UserActions.All;
+export type UserGetAction = UserActions.Get;
+
+@Injectable()
+export class UserEffects {
+  constructor(
+    private actions$: Actions,
+    private userService: UserService,
+    private notifications: Notifications,
+  ) {}
+
+  @Effect() getCollaboratorsSuccess$: Observable<UserAction> = this.actions$
+    .ofType(CollaboratorActions.GET_SUCCESS)
+    .map((action: CollabGetSuccess) => {
+      return new UserActions.Set(normalizeArray<UserUI>(action.payload));
+    });
+
+  @Effect() getUser$: Observable<UserAction> = this.actions$
+    .ofType(UserActions.GET)
+    .switchMap((action: UserGetAction) => {
+      return this.userService.getUserByUserId(action.payload)
+        .map((user: UserServiceModel) => {
+          const userMapper = new UserMapper();
+          const mappedUser: UserUI = userMapper.toUIModel(user);
+          return new UserActions.Set(normalizeArray<UserUI>([mappedUser]));
+        })
+    });
+}

--- a/src/app/models/comment.spec.ts
+++ b/src/app/models/comment.spec.ts
@@ -11,8 +11,7 @@ describe('Unit Test :: Comment Model', () => {
   });
 
   it('should correctly convert to UI model - 1', () => {
-    const userMapper = new UserMapper();
-    const cm = new CommentMapper(userMapper);
+    const cm = new CommentMapper();
     const input: CommentService = {
       id: "5cd88093-53c2-4e7a-a7ee-6a74bfbbb204",
       attributes: {
@@ -40,13 +39,7 @@ describe('Unit Test :: Comment Model', () => {
       body: "comment",
       markup: "Markdown",
       createdAt: "2018-01-16T10:04:22.946692Z",
-      creator: {
-        id: "5cd88093",
-        name: null,
-        username: null,
-        avatar: null,
-        currentUser: false
-      },
+      creatorId: "5cd88093",
       bodyRendered: "<p>comment</p>",
       selfLink: "https://api.openshift.io/api/comments/2e7c4d7c-dd2b-465b-ad76-6115068a1184"
     };

--- a/src/app/models/common.model.spec.ts
+++ b/src/app/models/common.model.spec.ts
@@ -1,7 +1,8 @@
 import {
   switchModel,
   cleanObject,
-  MapTree
+  MapTree,
+  normalizeArray
 } from "./common.model";
 
 describe('Unit Test :: Common model', () => {
@@ -206,3 +207,75 @@ describe('Unit Test :: Common model :: Object cleaner', () => {
     return expect(output).toEqual(expOutput);
   })
 })
+
+describe('Unit Test :: normalizeArray', () => {
+  type testType = {
+    id?: string;
+    name: string;
+    add: string;
+  }
+
+  it('Should work for an empty array', () => {
+    const op = normalizeArray<any>([]);
+    expect(op).toEqual({});
+  });
+
+  it('Should throw error for non-array input', () => {
+    expect(
+      // ignore the type error because this is the test
+      function(){ normalizeArray<any>('string'); } // tslint:disable-line
+    ).toThrow(new Error('The input needs to be an array'));
+  });
+
+  it('Should normalize array of objects without \'id\' key by the index', () => {
+    const input: testType[] = [{
+      name: 'Sudipta',
+      add: 'Alpine Eco'
+    }, {
+      name: 'Ibrahim',
+      add: 'Brigade'
+    }];
+
+    const expectedOp: {[id: string]: testType} = {
+      '0': {
+        name: 'Sudipta',
+        add: 'Alpine Eco'
+      },
+      '1': {
+        name: 'Ibrahim',
+        add: 'Brigade'
+      }
+    };
+
+    const op = normalizeArray<testType>(input);
+    expect(op).toEqual(expectedOp);
+  });
+
+  it('Should normalize array of objects with \'id\' key by the id', () => {
+    const input: testType[] = [{
+      id: '1',
+      name: 'Sudipta',
+      add: 'Alpine Eco'
+    }, {
+      id: '2',
+      name: 'Ibrahim',
+      add: 'Brigade'
+    }];
+
+    const expectedOp: {[id: string]: testType} = {
+      '1': {
+        id: '1',
+        name: 'Sudipta',
+        add: 'Alpine Eco'
+      },
+      '2': {
+        id: '2',
+        name: 'Ibrahim',
+        add: 'Brigade'
+      }
+    };
+
+    const op = normalizeArray<testType>(input);
+    expect(op).toEqual(expectedOp);
+  });
+});

--- a/src/app/models/common.model.ts
+++ b/src/app/models/common.model.ts
@@ -128,3 +128,24 @@ export function cleanObject(obj: any, keysToRemove: string[] = []): any {
   }
   return obj;
 }
+
+
+/**
+ * This function normalize the array to
+ * a key value paired dictionary
+ * @param arr
+ */
+export function normalizeArray<I>(arr: I[]): {[id: string]: I} {
+  if (!Array.isArray(arr)) {
+    throw(new Error('The input needs to be an array'));
+  }
+  let output = {};
+  arr.forEach((item, index) => {
+    if (item.hasOwnProperty('id')) {
+      output[item['id'].toString()] = item;
+    } else {
+      output[index.toString()] = item;
+    }
+  });
+  return output;
+}

--- a/src/app/models/user.ts
+++ b/src/app/models/user.ts
@@ -1,3 +1,5 @@
+import { AppState } from './../states/app.state';
+import { Store } from '@ngrx/store';
 import {
   modelUI,
   modelService,
@@ -69,4 +71,11 @@ export class UserMapper implements Mapper<UserService, UserUI> {
       arg, this.uiToServiceMapTree
     )
   }
+}
+
+class UserResolver {
+  constructor(store: Store<AppState>) {
+
+  }
+
 }

--- a/src/app/models/user.ts
+++ b/src/app/models/user.ts
@@ -79,7 +79,7 @@ export class UserMapper implements Mapper<UserService, UserUI> {
 }
 
 @Injectable()
-export class UserResolver {
+export class UserQuery {
   store: Store<AppState>;
   constructor(store: Store<AppState>) {
     this.store = store;

--- a/src/app/models/work-item.ts
+++ b/src/app/models/work-item.ts
@@ -149,7 +149,6 @@ export class WorkItemMapper implements Mapper<WorkItemService, WorkItemUI> {
   areaMapper = new AreaMapper();
   userMapper = new UserMapper();
   labelMapper = new LabelMapper();
-  commentMapper = new CommentMapper(this.userMapper);
 
   serviceToUiMapTree: MapTree = [{
       fromPath: ['id'],

--- a/src/app/reducers/index.reducer.ts
+++ b/src/app/reducers/index.reducer.ts
@@ -14,3 +14,4 @@ export { DetailWorkItemReducer } from './detail-work-item.reducer';
 export { LinkTypeReducer } from './link-type.reducer';
 export { WorkItemLinkReducer } from './work-item-link.reducer';
 export { InfotipReducer } from './infotip.reducer';
+export { UserReducer } from './user.reducer';

--- a/src/app/reducers/user.reducer.spec.ts
+++ b/src/app/reducers/user.reducer.spec.ts
@@ -1,0 +1,90 @@
+import { UserUI } from './../models/user';
+import { UserReducer } from './user.reducer';
+import { initialState as UserInitialState, UserState } from './../states/user.state';
+import * as UserActions from './../actions/user.actions';
+
+export type Action = UserActions.All;
+
+describe('Unit Test :: UserReducer', () => {
+  it('undefined action should return the default state', () => {
+    const action = {} as Action;
+    const state = UserReducer(undefined, action);
+    expect(state).toBe(UserInitialState);
+  });
+
+  it('Initial state should be an empty object', () => {
+    const initialState = {};
+    expect(UserInitialState).toEqual(initialState);
+  });
+
+
+  it('get action should return payload as state', () => {
+    const users: UserState = {
+      "1": {
+        id: "1",
+        name: 'user 1',
+        avatar: 'user1.jpg',
+        username: 'user1',
+        currentUser: false
+      },
+      "2": {
+        id: "2",
+        name: 'user 2',
+        avatar: 'user2.jpg',
+        username: 'user2',
+        currentUser: false
+      }
+    };
+    const action = new UserActions.Set(users);
+    const state = UserReducer(undefined, action);
+    expect(state).toEqual(users);
+  });
+
+  it('add action should add an user to existing state - 1', () => {
+    const newUsers: UserState = {
+      "1": {
+        id: "1",
+        name: 'user 1',
+        avatar: 'user1.jpg',
+        username: 'user1',
+        currentUser: false
+      }
+    };
+
+    const action = new UserActions.Set(newUsers);
+    const state = UserReducer(undefined, action);
+    expect(state).toEqual(newUsers);
+  });
+
+  it('add action should add an user to existing state - 2', () => {
+    const previousState: UserState = {
+      "1": {
+        id: "1",
+        name: 'user 1',
+        avatar: 'user1.jpg',
+        username: 'user1',
+        currentUser: false
+      },
+      "2": {
+        id: "2",
+        name: 'user 2',
+        avatar: 'user2.jpg',
+        username: 'user2',
+        currentUser: false
+      }
+    };
+    const newUsers: UserState = {
+      "3": {
+        id: "3",
+        name: 'user 3',
+        avatar: 'user3.jpg',
+        username: 'user3',
+        currentUser: false
+      }
+    };
+    const action = new UserActions.Set(newUsers);
+    const state = UserReducer(previousState, action);
+    expect({...state}).toEqual({...{...previousState, ...newUsers}});
+  });
+});
+

--- a/src/app/reducers/user.reducer.ts
+++ b/src/app/reducers/user.reducer.ts
@@ -1,0 +1,20 @@
+import { State } from '@ngrx/store';
+import { ActionReducer } from '@ngrx/store';
+import * as UserActions from './../actions/user.actions';
+
+import { UserState, initialState } from '../states/user.state';
+
+export type Action = UserActions.All;
+
+export const UserReducer: ActionReducer<UserState> =
+  (state = initialState, action: Action) => {
+  if (!state) state = {};
+  switch(action.type) {
+    case UserActions.SET: {
+      return {...state, ...action.payload};
+    }
+    default: {
+      return state;
+    }
+  }
+}

--- a/src/app/states/app.state.ts
+++ b/src/app/states/app.state.ts
@@ -6,7 +6,7 @@ export interface AppState {
     labels: states.LabelState,
     areas: states.AreaState,
     collaborators: states.CollaboratorState,
-    users: states.UserState
+    users: states.UserState,
     workItems: states.WorkItemState,
     groupTypes: states.GroupTypeState,
     space: states.SpaceState,

--- a/src/app/states/app.state.ts
+++ b/src/app/states/app.state.ts
@@ -6,6 +6,7 @@ export interface AppState {
     labels: states.LabelState,
     areas: states.AreaState,
     collaborators: states.CollaboratorState,
+    users: states.UserState
     workItems: states.WorkItemState,
     groupTypes: states.GroupTypeState,
     space: states.SpaceState,

--- a/src/app/states/index.state.ts
+++ b/src/app/states/index.state.ts
@@ -65,3 +65,7 @@ export {
   InfotipState,
   initialState as initialInfotipState
 } from './infotip.state';
+export {
+  UserState,
+  initialState as inititalUserState
+} from './user.state';

--- a/src/app/states/user.state.ts
+++ b/src/app/states/user.state.ts
@@ -1,0 +1,7 @@
+import { UserUI } from './../models/user';
+
+export type UserState = {
+  [userId: string]: UserUI
+}
+
+export const initialState: UserState = {};


### PR DESCRIPTION
In this PR we have normalized the user data. Now we have a state called `users` under `listPage` which holds the data **not** in a form of an array but a form of a normalized object. 
For example, if previously the data used to look like - 
```
const users = [{
      id: '1',
      name: 'Sudipta',
      add: 'Alpine Eco'
    }, {
      id: '2',
      name: 'Ibrahim',
      add: 'Brigade'
    }]
```
Now they look like 
```
const users = {
      '1': {
        id: '1',
        name: 'Sudipta',
        add: 'Alpine Eco'
      },
      '2': {
        id: '2',
        name: 'Ibrahim',
        add: 'Brigade'
      }
    }
```

**What does it solve?**
Now we don't copy the data to resolve it for some other attribute. For example consider `comment`, where `creator` is a relationship that relates to `user`. Previously, after fetching the `comment` we used to resolve the `creator` from the list of `users` and simply copy it to the creator section. Something like this - 
```
const comment = {
    id: 'comment-0',
    cretor: {
        id: '1',
        name: 'Sudipta',
        add: 'Alpine Eco'
      }, 
      message: 'This is a comment'
}
```
and there are various problem with this model, first, we are redundending the data, second comment will have no clue if the user's name is changed, third we rely only on the list of users that is fetched previously thus a non-collborator commentor's name and avatar is not shown right now (which is fixed in this implementation) and last but not the least in order to update the `user` the whole DOM tree of comment will be effected. 
So, now the comment data looks something like this - 
```
const comment = {
    id: 'comment-0',
    cretor: this.store.select('listPage').select('users').select(creator_id), // a store observable instance
    message: 'This is a comment'
}
```
Adn all we have to do in template to print the user name is 
``` 
<div *ngIf="comment.creator | async as creator">{{ creator.name }}</div>
 ```
Since, `comment.creator` is now an observable it's easy to watch over any change on that particular user and it'll update just this part of the DOM without effecting the entire comment section.

## Update

I recently had a question in mind, if storing the `Observable` into the store is a good idea? I checked with people from ngrx with this https://github.com/ngrx/platform/issues/1076 and turned out it's not. 

So we are not going to do the following - 
```
const comment = {
    id: 'comment-0',
    cretor: this.store.select('listPage').select('users').select(creator_id), // a store observable instance
    message: 'This is a comment'
}
```
Instead, we are going to keep the raw id of the relations like the following 

```
const comment = {
    id: 'comment-0',
    creator: creator_id
    message: 'This is a comment'
}
```
**But then are we going to resolve the data in the component?**
No, because these **queries are common for multiple components**, besides **we want to keep our components clean from `Store` import**. So I am adding **Injectable Query classes** to the attribute models.
For example, in this PR you'll find - 
`UserQuery` -> https://github.com/fabric8-ui/fabric8-planner/pull/2646/commits/1d809af356808b2f0e2ce0807f89a77caa6b8a8a#diff-b8f872575d850524306aa76adff1ca6eL76
`CommentQuery` -> https://github.com/fabric8-ui/fabric8-planner/pull/2646/commits/229ddd873b20071a781be36c70004157bf6e302f#diff-30f2bcacbe12a755d8c282d5a2a4498fR129
These query classes will be responsible for resolving and calculating query values for any attributes. 

## References - 
* https://netbasal.com/querying-a-normalized-state-with-rxjs-in-angular-71ecd7ca25b4
* https://netbasal.com/lets-talk-about-select-and-reselect-in-ngrx-store-177a2f6045a8