### PR TITLE
feat(Makefile): use Makefile for running tasks, retiring gulp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ watch: watchjs watchcss watchhtml watchfiles
 
 clean: cleancache cleandist cleanimages cleanmodules cleantemp
 
+test: testunit
+
 processjs:
 	# Compiling TypeScript to JavaScript...
 	# (according to the configs set in default tsconfig.json)
@@ -66,3 +68,5 @@ cleanimages:
 cleanmodules: ; @rm -rf node_modules
 
 cleantemp: ; @rm -rf tmp coverage typings .sass-cache
+
+testunit: ; @./node_modules/karma/bin/karma start

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 # First off, let's fetch in the executables installed with npm
 PATH  := node_modules/.bin:$(PATH)
 
+# Build the entire library
 build: processjs processcss processhtml processfiles
 
+# Watch build files for change, rebuild if they are changed
 watch: watchjs watchcss watchhtml watchfiles
 
+# Clean up the project
 clean: cleancache cleandist cleanimages cleanmodules cleantemp
 
+# Run tests
 test: testunit
 
 processjs:
@@ -19,21 +23,22 @@ processjs:
 		sed -i -r -e "s/templateUrl:\s+('.+')/template: require(\1)/g" $$jsfile; \
 		sed -i -r -e "s/styleUrls:\s+\[('.+')\]/styles: \[require(\1).toString()\]/g" $$jsfile; \
 	done
+	# Processing JS: DONE
 
-watchjs:
-	@chokidar --verbose 'src/**/*.ts' -c 'make processjs'
+watchjs: ; @chokidar --verbose 'src/**/*.ts' -c 'make processjs'
 
 processcss:
 	# Compiling LESS to CSS
 	# @TODO: lesshint report & failOnError
+	# @TODO: Compile only the changed file
 	@for lessfile in `find src -name '*.less'`; do \
 		csspath="$${lessfile/src/dist}"; \
 		cssfile="$${csspath/\.less/\.css}"; \
 		lessc --source-map --autoprefix="last 2 versions" $$lessfile $$cssfile; \
 	done
+	# Processing CSS: DONE
 
-watchcss:
-	@chokidar --verbose 'src/**/*.less' -c 'make processcss'
+watchcss: ; @chokidar --verbose 'src/**/*.less' -c 'make processcss'
 
 processhtml:
 	# Copying HTML over to respective paths in dist directory
@@ -44,17 +49,17 @@ processhtml:
 		mkdir -p $$htmldest; \
 		cp $$htmlfile $$htmldest; \
 	done
+	# Processing HTML: DONE
 
-watchhtml:
-	@chokidar --verbose 'src/**/*.html' -c 'make processhtml'
+watchhtml: ; @chokidar --verbose 'src/**/*.html' -c 'make processhtml'
 
 processfiles:
 	# Copying LICENSE README.adoc & package.json over to dist/
 	mkdir -p dist
 	@cp LICENSE README.adoc package.json dist/
+	# Processing misc files: DONE
 
-watchfiles:
-	@chokidar --verbose 'LICENSE' 'README.adoc' 'package.json' -c 'make processfiles'
+watchfiles: ; @chokidar --verbose 'LICENSE' 'README.adoc' 'package.json' -c 'make processfiles'
 
 cleancache: ; @npm cache clean
 
@@ -67,6 +72,6 @@ cleanimages:
 
 cleanmodules: ; @rm -rf node_modules
 
-cleantemp: ; @rm -rf tmp coverage typings .sass-cache
+cleantemp: ; @rm -rf tmp coverage typings
 
 testunit: ; @./node_modules/karma/bin/karma start

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+# First off, let's fetch in the executables installed with npm
+PATH  := node_modules/.bin:$(PATH)
+
+.PHONY: build
+
+.PHONY: watch
+
+build: processjs processcss processhtml processfiles
+
+watch: watchjs watchcss watchhtml watchfiles
+
+processjs:
+	# Compiling TypeScript to JavaScript...
+	# (according to the configs set in default tsconfig.json)
+	@tsc
+
+	# This hack is required to make the templates/styles consumable with require()
+	@for jsfile in `find dist/app -name '*.js'`; do \
+		sed -i -r -e "s/templateUrl:\s+('.+')/template: require(\1)/g" $$jsfile; \
+		sed -i -r -e "s/styleUrls:\s+\[('.+')\]/styles: \[require(\1).toString()\]/g" $$jsfile; \
+	done
+
+watchjs:
+	@chokidar --verbose 'src/**/*.ts' -c 'make processjs'
+
+processcss:
+	# Compiling LESS to CSS
+	# @TODO: lesshint report & failOnError
+	@for lessfile in `find src -name '*.less'`; do \
+		csspath="$${lessfile/src/dist}"; \
+		cssfile="$${csspath/\.less/\.css}"; \
+		lessc --source-map --autoprefix="last 2 versions" $$lessfile $$cssfile; \
+	done
+
+watchcss:
+	@chokidar --verbose 'src/**/*.less' -c 'make processcss'
+
+processhtml:
+	# Copying HTML over to respective paths in dist directory
+	@for htmlfile in `find src -name '*.html'`; do \
+		htmlname=$$(basename $$htmlfile); \
+		htmlpath="$${htmlfile/src/dist}"; \
+		htmldest="$${htmlpath/$$htmlname/}"; \
+		cp $$htmlfile $$htmldest; \
+	done
+
+watchhtml:
+	@chokidar --verbose 'src/**/*.html' -c 'make processhtml'
+
+processfiles:
+	# Copying LICENSE README.adoc & package.json over to dist/
+	@cp LICENSE README.adoc package.json dist/
+
+watchfiles:
+	@chokidar --verbose 'LICENSE' 'README.adoc' 'package.json' -c 'make processfiles'

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,11 @@
 # First off, let's fetch in the executables installed with npm
 PATH  := node_modules/.bin:$(PATH)
 
-.PHONY: build
-
-.PHONY: watch
-
 build: processjs processcss processhtml processfiles
 
 watch: watchjs watchcss watchhtml watchfiles
+
+clean: cleancache cleandist cleanimages cleanmodules cleantemp
 
 processjs:
 	# Compiling TypeScript to JavaScript...
@@ -41,6 +39,7 @@ processhtml:
 		htmlname=$$(basename $$htmlfile); \
 		htmlpath="$${htmlfile/src/dist}"; \
 		htmldest="$${htmlpath/$$htmlname/}"; \
+		mkdir -p $$htmldest; \
 		cp $$htmlfile $$htmldest; \
 	done
 
@@ -49,7 +48,21 @@ watchhtml:
 
 processfiles:
 	# Copying LICENSE README.adoc & package.json over to dist/
+	mkdir -p dist
 	@cp LICENSE README.adoc package.json dist/
 
 watchfiles:
 	@chokidar --verbose 'LICENSE' 'README.adoc' 'package.json' -c 'make processfiles'
+
+cleancache: ; @npm cache clean
+
+cleandist: ; @rm -rf dist
+
+cleanimages:
+	@sudo docker stop $$(sudo docker ps -aq --filter "name=fabric8-planner")
+	@sudo docker rm $$(sudo docker ps -aq --filter "name=fabric8-planner")
+	@sudo docker rmi $$(sudo docker images -aq --filter "reference=fabric8-planner-*")
+
+cleanmodules: ; @rm -rf node_modules
+
+cleantemp: ; @rm -rf tmp coverage typings .sass-cache

--- a/README.adoc
+++ b/README.adoc
@@ -141,6 +141,41 @@ v|`npm run tests \-- --smok`
 
 |===
 
+These tasks can also be run as make targets:
+
+[cols="1,1,3", options="header"]
+|===
+|Target
+|Command
+|Description
+
+| *Build*
+v|`make build`
+a| Builds the planner library.
+
+Runs `processjs` `processcss` `processhtml` & `processfiles` subroutines, which may as well be called individually with `make`
+
+| *Watch*
+v|`make watch`
+a| Watches source files for change, recompiles on change
+
+Runs `watchjs` `watchcss` `watchhtml` & `watchfiles` subroutines, which may as well be called individually with `make`
+
+| *Clean*
+v|`make clean`
+| Fully resets the project, cleaning up all artefacts
+
+Runs `cleancache` `cleandist` `cleanimages` `cleanmodules` & `cleantemp` subroutines, which may as well be called individually with `make`
+
+| *Test*
+v|`make test`
+a| Invokes tests (only runs unit tests for now)
+
+Runs `testunit` subroutine , which may as well be called individually with `make`
+
+3+a| To use the targets, run `make [make-options] _targetname_` for e.g. `$ make -j4 watch` to run watch target with 4 parallel threads.
+|===
+
 == Documentation
 The following documentation is available in the *_docs_* directory:
 

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@ngrx/effects": "^4.1.1",
     "@ngrx/store": "^4.1.1",
     "@ngrx/store-devtools": "^4.1.1",
+    "chokidar-cli": "^1.2.0",
     "core-js": "^2.5.1",
     "less-plugin-autoprefix": "^1.5.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
 ## What does this PR do?
This sets up the base to replace Gulp as a task runner, with Make. For the moment, both will work so that developers can get accustomed with the new set of commands. Once the transition phase is over, Gulp can be safely removed from repo and Make can take its place as user-run commands as well as in CI/CD routines.

## What issue/task does this PR references?
#2506 & https://openshift.io/openshiftio/openshiftio/plan/detail/2419

## Are the tests Included?
Not Applicable