### PR TITLE
fix(work-item-cell):  Iteration name issue fixed

### DIFF
--- a/src/app/components_ngrx/iteration-list-entry/iteration-list-entry.component.html
+++ b/src/app/components_ngrx/iteration-list-entry/iteration-list-entry.component.html
@@ -48,7 +48,8 @@
   <a 
     class="f8-itr__header"
     [routerLink]="[]" 
-    [queryParams]="addRemoveQueryParams(iteration.id)">
+    [queryParams]="addRemoveQueryParams(iteration.id)"
+    title="{{iteration.name}}">
     <div class="truncate padding-right-15">
       <span class="f8-itr-name truncate">{{iteration.name | truncate : 15}}</span>
       <span class="active-tag"

--- a/src/app/components_ngrx/iteration-list-entry/iteration-list-entry.component.less
+++ b/src/app/components_ngrx/iteration-list-entry/iteration-list-entry.component.less
@@ -58,7 +58,6 @@
     color: @color-pf-black-600;
   }
   .active-tag {
-    padding-left: 10px;
     font-size: 12px;
     font-weight: 600;
     color: @color-pf-black-600;

--- a/src/app/components_ngrx/iterations-panel/iterations-panel.component.html
+++ b/src/app/components_ngrx/iterations-panel/iterations-panel.component.html
@@ -33,7 +33,9 @@
       <a
         [routerLinkActive]="'f8-itr--selected'"
         [routerLink]="[]" [attr.data-id]="iteration.id"
-        [queryParams]="addRemoveQueryParams(iteration.id)">
+        [queryParams]="addRemoveQueryParams(iteration.id)"
+        title="{{ iteration.resolvedParentPath +
+          '/' + iteration.name }}">
           <span id="{{ iteration.resolvedParentPath +
               '/' + iteration.name }}">
             {{iteration.resolvedParentPath +

--- a/src/app/components_ngrx/iterations-panel/iterations-panel.component.less
+++ b/src/app/components_ngrx/iterations-panel/iterations-panel.component.less
@@ -34,7 +34,6 @@
         border-top-color: @color-pf-black;
       }
       a {
-        padding: 5px 10px;
         color: @color-pf-white;
         &:hover {
           text-decoration: none;

--- a/src/app/components_ngrx/planner-list/planner-list.module.ts
+++ b/src/app/components_ngrx/planner-list/planner-list.module.ts
@@ -35,6 +35,7 @@ import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { FilterColumn } from '../../pipes/column-filter.pipe';
 import { WorkItemDataService } from './../../services/work-item-data.service';
 import { PlannerModalModule } from '../../components/modal/modal.module';
+import { TruncateModule } from 'ng2-truncate';
 
 import { CookieService } from './../../services/cookie.service';
 import { FilterService } from './../../services/filter.service';
@@ -127,6 +128,7 @@ if (process.env.ENV == 'inmemory') {
     BsDropdownModule.forRoot(),
     NgxDatatableModule,
     WorkItemPreviewPanelModule,
+    TruncateModule,
     StoreModule.forFeature('listPage', {
         iterations: reducers.iterationReducer,
         labels: reducers.LabelReducer,

--- a/src/app/components_ngrx/work-item-cell/work-item-cell.component.html
+++ b/src/app/components_ngrx/work-item-cell/work-item-cell.component.html
@@ -53,7 +53,7 @@
 
 <!-- Iteration -->
   <span id="table-iteration" *ngIf="col === 'iteration'">
-    {{row.iteration?.parentPath === '/' ? 'NA' : row.iteration?.name}}
+    {{row.iteration?.parentPath === '/' ? 'NA' : row.iteration?.name | truncate : 15}}
   </span>
 
 <!-- Creator -->

--- a/src/app/components_ngrx/work-item-cell/work-item-cell.component.html
+++ b/src/app/components_ngrx/work-item-cell/work-item-cell.component.html
@@ -56,7 +56,7 @@
         title="{{row.iteration?.parentPath === '/' ? 'NA' 
         : row.iteration?.name}}"
         *ngIf="col === 'iteration'">
-    {{row.iteration?.parentPath === '/' ? 'NA' : row.iteration?.name | truncate : 15}}
+    {{row.iteration?.parentPath === '/' ? 'NA' : row.iteration?.name | truncate : 18}}
   </span>
 
 <!-- Creator -->

--- a/src/app/components_ngrx/work-item-cell/work-item-cell.component.html
+++ b/src/app/components_ngrx/work-item-cell/work-item-cell.component.html
@@ -52,7 +52,10 @@
 </div>
 
 <!-- Iteration -->
-  <span id="table-iteration" *ngIf="col === 'iteration'">
+  <span id="table-iteration" 
+        title="{{row.iteration?.parentPath === '/' ? 'NA' 
+        : row.iteration?.name}}"
+        *ngIf="col === 'iteration'">
     {{row.iteration?.parentPath === '/' ? 'NA' : row.iteration?.name | truncate : 15}}
   </span>
 


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/3613

- Now in the work item list only first 18 characters of the iteration name are displayed and the rest gets 
  truncated and the full name is displayed on hover
- Active Iteration name does not break the UI for iteration panel now.