### PR TITLE
fix(label): createLabel service method is changed to use the URL as arg

### DIFF
--- a/src/app/effects/label.effects.ts
+++ b/src/app/effects/label.effects.ts
@@ -38,9 +38,9 @@ export class LabelEffects {
 
   @Effect() createLabel$: Observable<Action> = this.actions$
     .ofType<LabelActions.Add>(LabelActions.ADD)
-    .map(action => action.payload)
-    .switchMap(payload => {
-      return this.labelService.createLabel(payload)
+    .withLatestFrom(this.store.select('listPage').select('space'))
+    .switchMap(([action, space])  => {
+      return this.labelService.createLabel(action.payload, space.links.self + '/labels')
         .map(label => {
           const lMapper = new LabelMapper();
           let labelUI = lMapper.toUIModel(label);

--- a/src/app/services/label.service.ts
+++ b/src/app/services/label.service.ts
@@ -51,14 +51,10 @@ export class LabelService {
     });
   }
 
-  createLabel(label: LabelModel): Observable<LabelModel> {
-    return this.spaces.current.switchMap(
-      currentSpace => {
-        return this.http.post(currentSpace.links.self + '/labels', {data: label});
-      }
-    )
-    .map (response => {
-      return response.json().data as LabelModel;
-    });
+  createLabel(label: LabelModel, url: string): Observable<LabelModel> {
+    return this.http.post(url, {data: label})
+      .map (response => {
+        return response.json().data as LabelModel;
+      });
   }
 }


### PR DESCRIPTION
<strong>Note: If there are pending changes to the PR, prefix the PR title with "WIP" and add the label "DO NOT MERGE"</strong>

### Mandatory
 - [x] What does this PR do? 
        In this PR the label service does not depend on any space-related data anymore. 
- [x] What issue/task does this PR references?
        https://github.com/openshiftio/openshift.io/issues/3028
- [x] Are the tests Included?
        No, this change doesn't require any test at this moment. Tests will be written for the entire service in coming updates.
___
### Optional
- [ ] Is the documentation Included?

- [ ] Are the Release Notes included?
<!-- For inclusion in marketing announcement - N/A for bugs. -->
<!-- A brief two line documentation of the functionality added/improved -->

- [ ] @mention(s) to expected reviewer(s) included
