### PR TITLE
fix(custom-query) : Input gets cleared after saving custom-query

### DIFF
--- a/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.html
+++ b/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.html
@@ -46,12 +46,12 @@
         </aside>
         <div>
           <input class="form-control ng-pristine ng-valid ng-touched"
-          (keyup.enter)="saveFilters(filterSaveInp.value)"
-          #filterSaveInp />
+          (keyup.enter)="saveFilters(filterSaveInp,filterSaveInp.value)"
+          #filterSaveInp/>
         </div>
         <div class="save-filter-action">
           <button class="btn btn-primary pull-right margin-left-5 save-cq-btn"
-            (click)="saveFilters(filterSaveInp.value)"
+            (click)="saveFilters(filterSaveInp,filterSaveInp.value)"
             [disabled]="!filterSaveInp.value">Save</button>
           <button class="btn pull-right margin-right-5 cancel-cq-btn" (click)="closeFilterSave()">Cancel</button>
         </div>

--- a/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.html
+++ b/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.html
@@ -46,12 +46,12 @@
         </aside>
         <div>
           <input class="form-control ng-pristine ng-valid ng-touched"
-          (keyup.enter)="saveFilters(filterSaveInp,filterSaveInp.value)"
+          (keyup.enter)="saveFilters(filterSaveInp)"
           #filterSaveInp/>
         </div>
         <div class="save-filter-action">
           <button class="btn btn-primary pull-right margin-left-5 save-cq-btn"
-            (click)="saveFilters(filterSaveInp,filterSaveInp.value)"
+            (click)="saveFilters(filterSaveInp)"
             [disabled]="!filterSaveInp.value">Save</button>
           <button class="btn pull-right margin-right-5 cancel-cq-btn" (click)="closeFilterSave()">Cancel</button>
         </div>

--- a/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.html
+++ b/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.html
@@ -42,7 +42,7 @@
       <div *dropdownMenu class="dropdown-menu-{{dropdownPlacement}} dropdown-menu">
         <aside>
           <i class="db text-right fa fa-close btn btn-link"
-            (click)="closeFilterSave()"></i>
+            (click)="closeFilterSave(filterSaveInp)"></i>
         </aside>
         <div>
           <input class="form-control ng-pristine ng-valid ng-touched"
@@ -53,7 +53,7 @@
           <button class="btn btn-primary pull-right margin-left-5 save-cq-btn"
             (click)="saveFilters(filterSaveInp)"
             [disabled]="!filterSaveInp.value">Save</button>
-          <button class="btn pull-right margin-right-5 cancel-cq-btn" (click)="closeFilterSave()">Cancel</button>
+          <button class="btn pull-right margin-right-5 cancel-cq-btn" (click)="closeFilterSave(filterSaveInp)">Cancel</button>
         </div>
       </div>
     </div>

--- a/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.ts
+++ b/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.ts
@@ -593,8 +593,8 @@ export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnDestroy {
     });
   }
 
-  saveFilters(filterSaveInp,filterName: string) {
-    if (filterName !== '') {
+  saveFilters(filterSaveInp: HTMLInputElement) {
+    if (filterSaveInp.value !== '') {
       //let exp = JSON.stringify(this.filterService.queryToJson(this.queryExp));
       let exp = this.queryExp;
       let e1 = this.filterService.queryToJson(exp);
@@ -602,15 +602,13 @@ export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnDestroy {
       let customQuery = {
         'attributes': {
           'fields': str,
-          'title': filterName
+          'title': filterSaveInp.value
         },
         'type': 'queries'
       };
       this.store.dispatch(new CustomQueryActions.Add(customQuery));
       this.closeFilterSave();
-      if(filterSaveInp) {
-        filterSaveInp.value = '';
-      }
+      filterSaveInp.value = '';
     }
   }
 

--- a/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.ts
+++ b/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.ts
@@ -593,7 +593,7 @@ export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnDestroy {
     });
   }
 
-  saveFilters(filterName: string) {
+  saveFilters(filterSaveInp,filterName: string) {
     if (filterName !== '') {
       //let exp = JSON.stringify(this.filterService.queryToJson(this.queryExp));
       let exp = this.queryExp;
@@ -608,6 +608,9 @@ export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnDestroy {
       };
       this.store.dispatch(new CustomQueryActions.Add(customQuery));
       this.closeFilterSave();
+      if(filterSaveInp) {
+        filterSaveInp.value = '';
+      }
     }
   }
 

--- a/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.ts
+++ b/src/app/components_ngrx/toolbar-panel/toolbar-panel.component.ts
@@ -607,8 +607,7 @@ export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnDestroy {
         'type': 'queries'
       };
       this.store.dispatch(new CustomQueryActions.Add(customQuery));
-      this.closeFilterSave();
-      filterSaveInp.value = '';
+      this.closeFilterSave(filterSaveInp);
     }
   }
 
@@ -664,8 +663,9 @@ export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  closeFilterSave() {
+  closeFilterSave(filterSaveInp: HTMLInputElement) {
     this.isFilterSaveOpen = false;
+    filterSaveInp.value = '';
   }
 
   saveFilterDropdownChange(value: boolean) {


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/3741

Input for custom-query name gets cleared once the query is saved and doesn't show up in the input field of the save custom-query drop-down the next time the save custom-query drop-down is opened.