### PR TITLE
fix(list): prevent query params after clicking on backlog

### DIFF
--- a/src/app/components_ngrx/planner-list/planner-list.component.ts
+++ b/src/app/components_ngrx/planner-list/planner-list.component.ts
@@ -224,6 +224,11 @@ export class PlannerListComponent implements OnInit, OnDestroy, AfterViewChecked
         .filter(event => event instanceof NavigationStart)
         .subscribe(
         (event: any) => {
+          if (event.url.indexOf('?q') === -1 &&
+            event.url.indexOf('/plan/detail/') === -1 &&
+            event.url.indexOf('/plan') > -1) {
+            this.setDefaultUrl();
+          }
           if (event.url.indexOf('/plan/detail/') > -1) {
             // It's going to the detail page
             let url = location.pathname;


### PR DESCRIPTION
<strong>Note: If there are pending changes to the PR, prefix the PR title with "WIP" and add the label "DO NOT MERGE"</strong>

### Mandatory
 - [ ] What does this PR do? 
Prevent query params after clicking on backlog or plan tab.
- [ ] What issue/task does this PR references?
https://github.com/openshiftio/openshift.io/issues/3762
- [ ] Are the tests Included?
No
