### PR TITLE
 fix(toast-notifications): Suppress create and update notifications

### DIFF
--- a/src/app/effects/custom-query.effects.ts
+++ b/src/app/effects/custom-query.effects.ts
@@ -67,14 +67,6 @@ export class CustomQueryEffects {
         if (customQueryName.length > 15) {
           customQueryName = customQueryName.slice(0, 15) + '...';
         }
-        try {
-          this.notifications.message({
-            message: `${customQueryName} added.`,
-            type: NotificationType.SUCCESS
-          } as Notification);
-        } catch (e) {
-          console.log('Custom query added.');
-        }
         return new CustomQueryActions.AddSuccess(customQuery);
       })
       .catch(() => {

--- a/src/app/effects/iteration.effects.ts
+++ b/src/app/effects/iteration.effects.ts
@@ -53,14 +53,6 @@ export class IterationEffects {
           if (iterationName.length > 15) {
             iterationName = iterationName.slice(0, 15) + '...';
           }
-          try {
-            this.notifications.message({
-              message: `${iterationName} is added.`,
-              type: NotificationType.SUCCESS
-            } as Notification);
-          } catch (e) {
-            console.log('Iteration is added.');
-          }
           return new IterationActions.AddSuccess({
             iteration, parent: parent ? itMapper.toUIModel(parent) : null
           });
@@ -91,14 +83,6 @@ export class IterationEffects {
           let iterationName = iteration.name;
           if (iterationName.length > 15) {
             iterationName = iterationName.slice(0, 15) + '...';
-          }
-          try {
-            this.notifications.message({
-              message: `${iterationName} is updated.`,
-              type: NotificationType.SUCCESS
-            } as Notification);
-          } catch (e) {
-            console.log('Error displaying notification.');
           }
           const payload = {
             iteration: iteration

--- a/src/app/effects/label.effects.ts
+++ b/src/app/effects/label.effects.ts
@@ -44,14 +44,6 @@ export class LabelEffects {
         .map(label => {
           const lMapper = new LabelMapper();
           let labelUI = lMapper.toUIModel(label);
-          try {
-            this.notifications.message({
-              message: `${labelUI.name} is added.`,
-              type: NotificationType.SUCCESS
-            } as Notification);
-          } catch (e) {
-            console.log('label is added');
-          }
           return new LabelActions.AddSuccess(labelUI);
         })
         .catch(e => {

--- a/src/app/effects/work-item.effects.ts
+++ b/src/app/effects/work-item.effects.ts
@@ -99,14 +99,6 @@ export class WorkItemEffects {
             }).map(() => {
               // for a normal (not a child) work item creation
               // Add item success notification
-              try {
-                this.notifications.message({
-                  message: `New child added.`,
-                  type: NotificationType.SUCCESS
-                } as Notification);
-              } catch (e) {
-                console.log('New child added.');
-              }
               const parent = state.workItems.entities[parentId];
               if (!parent.childrenLoaded && parent.hasChildren) {
                 return new WorkItemActions.GetChildren(parent);
@@ -121,14 +113,6 @@ export class WorkItemEffects {
           } else {
             // for a normal (not a child) work item creation
             // Add item success notification
-            try {
-              this.notifications.message({
-                message: `Work item is added.`,
-                type: NotificationType.SUCCESS
-              } as Notification);
-            } catch (e) {
-              console.log('Work item is added.');
-            }
             if (payload.openDetailPage) {
               this.router.navigateByUrl(document.location.pathname + '/detail/' + wItem.number,
                                         {relativeTo: this.route});
@@ -275,14 +259,6 @@ export class WorkItemEffects {
               w.treeStatus = item.treeStatus;
               w.childrenLoaded = item.childrenLoaded;
               w.parentID = item.parentID;
-            }
-            try {
-              this.notifications.message({
-                message: `Workitem updated.`,
-                type: NotificationType.SUCCESS
-              } as Notification);
-            } catch (e) {
-              console.log('workitem updated.');
             }
             return w;
           })

--- a/src/tests/page_objects/planner/planner.page.ts
+++ b/src/tests/page_objects/planner/planner.page.ts
@@ -40,6 +40,7 @@ export class PlannerPage extends AppPage {
     await this.createWorkItem({'title' : workItemTitle});
     return workItemTitle;
   }
+
   async createInlineWorkItem(item: planner.WorkItem) {
     this.debug('create inline item', JSON.stringify(item));
     await this.inlineQuickAdd.addInlineWorkItem(item);
@@ -48,6 +49,5 @@ export class PlannerPage extends AppPage {
   async resetState() {
     await this.sidePanel.clickScenarios();
     await $('body').sendKeys(Key.ESCAPE);
-    await this.quickPreview.notificationToast.untilHidden();
   }
 }

--- a/src/tests/specs/detailPage.spec.ts
+++ b/src/tests/specs/detailPage.spec.ts
@@ -21,8 +21,7 @@ describe('Detail View test: ', () => {
   });
 
   afterEach(async () => {
-    await browser.executeScript("document.getElementsByClassName('f8-detail--close')[0].click()");
-    await planner.quickPreview.notificationToast.untilHidden();
+    await planner.quickPreview.close();
   });
 
   it('should open detail view and apply label', async () => {

--- a/src/tests/specs/iteration.spec.ts
+++ b/src/tests/specs/iteration.spec.ts
@@ -64,7 +64,6 @@ describe('Iteration test', () => {
     await planner.sidePanel.openIterationDialogue();
     await planner.iteration.editIteration(updateIteration);
     await planner.workItemList.workItem(workItemTitle1).iteration.untilTextIsPresent(updateIteration);
-    await planner.quickPreview.notificationToast.untilCount(1);
     expect(await planner.workItemList.iterationText(workItemTitle1)).toBe(updateIteration);
   });
 

--- a/src/tests/specs/iteration.spec.ts
+++ b/src/tests/specs/iteration.spec.ts
@@ -58,10 +58,12 @@ describe('Iteration test', () => {
     await planner.workItemList.workItem(workItemTitle1).openQuickPreview();
     await planner.quickPreview.addIteration(dropdownIteration1);
     await planner.quickPreview.close();
+    await planner.workItemList.workItem(workItemTitle1).iteration.untilTextIsPresent(dropdownIteration1);
     expect(await planner.workItemList.iterationText(workItemTitle1)).toBe(dropdownIteration1);
     await planner.sidePanel.selectIterationKebab(dropdownIteration1);
     await planner.sidePanel.openIterationDialogue();
     await planner.iteration.editIteration(updateIteration);
+    await planner.workItemList.workItem(workItemTitle1).iteration.untilTextIsPresent(updateIteration);
     await planner.quickPreview.notificationToast.untilCount(1);
     expect(await planner.workItemList.iterationText(workItemTitle1)).toBe(updateIteration);
   });

--- a/src/tests/specs/quickPreview.spec.ts
+++ b/src/tests/specs/quickPreview.spec.ts
@@ -33,7 +33,6 @@ describe('Quick preview tests: ', () => {
     await planner.createWorkItem(workitemname);
     await planner.workItemList.clickWorkItem(workitemname.title);
     await planner.quickPreview.createNewLabel(c.newLabel);
-    await planner.quickPreview.notificationToast.untilHidden();
     expect(await planner.quickPreview.getLabels()).toContain(c.newLabel);
   });
 
@@ -43,7 +42,6 @@ describe('Quick preview tests: ', () => {
     await planner.createWorkItem(workitemname);
     await planner.workItemList.clickWorkItem(workitemname.title);
     await planner.quickPreview.createNewLabel(newLabel, true);
-    await planner.quickPreview.notificationToast.untilHidden();
     expect(await planner.quickPreview.getLabels()).toContain(newLabel);
   });
 
@@ -63,7 +61,6 @@ describe('Quick preview tests: ', () => {
     let title = await planner.createUniqueWorkItem();
     await planner.workItemList.clickWorkItem(title);
     await planner.quickPreview.updateTitle(c.editWorkItemTitle1);
-    await planner.quickPreview.notificationToast.untilHidden();
     expect(await planner.quickPreview.titleInput.getAttribute('value')).toBe('Title Text "<0>"');
   });
 

--- a/src/tests/specs/smoke/smokeTest.spec.ts
+++ b/src/tests/specs/smoke/smokeTest.spec.ts
@@ -186,6 +186,7 @@ describe('Planner Smoke Tests:', () => {
   it('Create a work item and Open detail page', async () => {
     let workitem = { title : 'new detail workItem', type: 'Scenario'};
     await planner.quickAdd.addAndOpenWorkItem(workitem);
+    await planner.waitUntilUrlContains('detail');
     await planner.detailPage.titleInput.untilTextIsPresentInValue('new detail workItem');
     await planner.detailPage.closeButton.ready();
     expect(await browser.getCurrentUrl()).toContain('detail');

--- a/src/tests/specs/smoke/smokeTest.spec.ts
+++ b/src/tests/specs/smoke/smokeTest.spec.ts
@@ -161,7 +161,6 @@ describe('Planner Smoke Tests:', () => {
     await planner.workItemList.overlay.untilHidden();
     await planner.header.saveFilters('My filter');
     await planner.workItemList.overlay.untilHidden();
-    await planner.quickPreview.notificationToast.untilHidden();
     await planner.sidePanel.customQuery.untilTextIsPresent('My filter');
     expect(await planner.sidePanel.getMyFiltersList()).toContain('My filter');
     await planner.sidePanel.selectcustomFilterKebab('My filter');
@@ -187,8 +186,6 @@ describe('Planner Smoke Tests:', () => {
   it('Create a work item and Open detail page', async () => {
     let workitem = { title : 'new detail workItem', type: 'Scenario'};
     await planner.quickAdd.addAndOpenWorkItem(workitem);
-    await planner.quickPreview.notificationToast.untilCount(1);
-    await planner.quickPreview.notificationToast.untilHidden();
     await planner.detailPage.closeButton.ready();
     expect(await browser.getCurrentUrl()).toContain('detail');
     await planner.detailPage.titleInput.untilTextIsPresentInValue('new detail workItem');
@@ -208,8 +205,6 @@ describe('Planner Smoke Tests:', () => {
     await planner.sidePanel.clickIteration('Iteration_1');
     await planner.quickAdd.addWorkItem({title : 'Add new work item to iteration test'});
     expect(await planner.workItemList.hasWorkItem('Add new work item to iteration test')).toBeTruthy();
-    await planner.quickPreview.notificationToast.untilCount(1);
-    await planner.quickPreview.notificationToast.untilHidden();
     await planner.sidePanel.clickScenarios();
     await planner.sidePanel.clickIteration('Iteration_1');
     expect(await planner.workItemList.hasWorkItem('Add new work item to iteration test')).toBeTruthy();

--- a/src/tests/specs/smoke/smokeTest.spec.ts
+++ b/src/tests/specs/smoke/smokeTest.spec.ts
@@ -186,9 +186,9 @@ describe('Planner Smoke Tests:', () => {
   it('Create a work item and Open detail page', async () => {
     let workitem = { title : 'new detail workItem', type: 'Scenario'};
     await planner.quickAdd.addAndOpenWorkItem(workitem);
+    await planner.detailPage.titleInput.untilTextIsPresentInValue('new detail workItem');
     await planner.detailPage.closeButton.ready();
     expect(await browser.getCurrentUrl()).toContain('detail');
-    await planner.detailPage.titleInput.untilTextIsPresentInValue('new detail workItem');
     await planner.detailPage.close();
     await planner.waitUntilUrlContains('typegroup');
     expect(await planner.workItemList.hasWorkItem('new detail workItem')).toBeTruthy();

--- a/src/tests/specs/workItemTableTest.spec.ts
+++ b/src/tests/specs/workItemTableTest.spec.ts
@@ -43,7 +43,6 @@ describe('Work Item datatable list: ', () => {
     await planner.workItemList.overlay.untilHidden();
     expect(await planner.workItemList.getInlineQuickAddClass(title)).toContain('disable');
     await planner.header.clickShowTree();
-    await planner.workItemList.overlay.untilHidden();
   });
 
   it('should filter work item by type', async () => {
@@ -59,7 +58,6 @@ describe('Work Item datatable list: ', () => {
     await planner.workItemList.overlay.untilHidden();
     await planner.createWorkItem(newWorkItem1);
     expect(await planner.workItemList.hasWorkItem(newWorkItem1.title)).toBeTruthy();
-    await planner.quickPreview.notificationToast.untilHidden();
     await planner.header.clickShowTree();
     expect(await planner.workItemList.hasWorkItem(newWorkItem1.title)).toBeTruthy();
   });
@@ -74,10 +72,8 @@ describe('Work Item datatable list: ', () => {
     expect(await planner.workItemList.hasWorkItem(newWorkItem.title)).toBeTruthy();
     await planner.workItemList.clickWorkItem(newWorkItem.title);
     await planner.quickPreview.changeStateTo('closed');
-    await planner.quickPreview.notificationToast.untilHidden();
     await planner.quickPreview.close();
     await planner.header.clickShowCompleted();
-    await planner.workItemList.overlay.untilHidden();
     expect(await planner.workItemList.hasWorkItem(newWorkItem.title, true)).toBeFalsy();
   });
 
@@ -95,7 +91,6 @@ describe('Work Item datatable list: ', () => {
     await planner.quickPreview.close();
     expect(await planner.workItemList.hasWorkItem(updatedWorkItem.title)).toBeTruthy();
     await planner.header.clickShowTree();
-    await planner.workItemList.overlay.untilHidden();
     expect(await planner.workItemList.hasWorkItem(updatedWorkItem.title)).toBeTruthy();
   });
 
@@ -108,7 +103,6 @@ describe('Work Item datatable list: ', () => {
     expect(await planner.workItemList.hasWorkItem(title)).toBeTruthy();
     await planner.workItemList.workItem(title).clickInlineQuickAdd();
     await planner.createInlineWorkItem(childWorkItem);
-    await planner.quickPreview.notificationToast.untilHidden();
     expect(await planner.workItemList.hasWorkItem(childWorkItem.title)).toBeTruthy();
     await planner.workItemList.clickWorkItem(title);
     await planner.quickPreview.createNewLabel(c.newLabel1);
@@ -125,7 +119,6 @@ describe('Work Item datatable list: ', () => {
     expect(await planner.workItemList.hasWorkItem(title)).toBeTruthy();
     await planner.workItemList.workItem(title).clickInlineQuickAdd();
     await planner.createInlineWorkItem(childWorkItem);
-    await planner.quickPreview.notificationToast.untilHidden();
     expect(await planner.workItemList.hasWorkItem(childWorkItem.title)).toBeTruthy();
     await planner.sidePanel.createNewIteration();
     await planner.iteration.addNewIteration(c.newIteration1, c.iteration3);
@@ -138,9 +131,10 @@ describe('Work Item datatable list: ', () => {
       workItemTitle4 = {'title': 'Workitem_Title_4'};
 
     await planner.sidePanel.clickRequirement();
+    await planner.waitUntilUrlContains('typegroup.name:Requirements');
     await planner.workItemList.workItem(workItemTitle4.title).clickInlineQuickAdd();
     await planner.createInlineWorkItem(workitemname);
-    await planner.quickPreview.notificationToast.untilHidden();
+    expect(await planner.workItemList.hasWorkItem(workitemname.title)).toBeTruthy();
     await planner.sidePanel.clickScenarios();
     await planner.waitUntilUrlContains('typegroup.name:Scenarios');
     await planner.sidePanel.clickRequirement();
@@ -167,12 +161,9 @@ describe('Work Item datatable list: ', () => {
   it('should update the workitem List on workitem edit', async () => {
     let workitem = {'title': 'TITLE_TEXT'};
     await planner.header.selectFilter('State', 'new');
-    await planner.workItemList.overlay.untilHidden();
     await planner.createWorkItem(workitem);
     await planner.workItemList.clickWorkItem(workitem.title);
     await planner.quickPreview.changeStateTo('open');
-    await planner.quickPreview.notificationToast.untilCount(1);
-    await planner.quickPreview.notificationToast.untilHidden();
     await planner.quickPreview.close();
     expect(await planner.workItemList.isTitleTextBold(workitem.title)).not.toContain('bold');
   });
@@ -180,7 +171,6 @@ describe('Work Item datatable list: ', () => {
   it('should make the title bold based on filter when adding a new workitem', async () => {
     let workitem = {'title': 'Scenario'};
     await planner.header.selectFilter('State', 'new');
-    await planner.workItemList.overlay.untilHidden();
     await planner.createWorkItem(workitem);
     expect(await planner.workItemList.hasWorkItem(workitem.title)).toBeTruthy();
     expect(await planner.workItemList.isTitleTextBold(workitem.title)).toContain('bold');
@@ -191,7 +181,6 @@ describe('Work Item datatable list: ', () => {
     await planner.workItemList.overlay.untilHidden();
     let countUnassignedWorkItem = await planner.workItemList.getUnassignedWorkItemCount(' Unassigned ');
     await planner.header.selectFilter('Assignee', 'Unassigned');
-    await planner.workItemList.overlay.untilHidden();
     await browser.sleep(1000);
     expect(await planner.header.getFilterConditions()).toContain(labelFilter);
     expect(await planner.workItemList.datatableRow.count()).toEqual(countUnassignedWorkItem);

--- a/src/tests/ui/planner/iteration.ts
+++ b/src/tests/ui/planner/iteration.ts
@@ -39,6 +39,7 @@ export class Iteration extends ui.BaseElement {
     await this.iterationName.clear();
     await this.iterationName.enterText(iterationName);
     await this.createIterationButton.clickWhenReady();
+    await this.createIterationButton.untilHidden();
   }
 
   async selectCalendarDate() {

--- a/src/tests/ui/planner/sidepanel.ts
+++ b/src/tests/ui/planner/sidepanel.ts
@@ -1,6 +1,7 @@
 import { $, by, ElementFinder } from 'protractor';
 import * as support from '../../support';
 import  *  as ui from './../../ui';
+import { WorkItemList } from './workitem-list';
 
 export class SidePanel extends ui.BaseElement {
   showHideSidePanelButton = new ui.Button(this.$('.f8-sidepanel--toggle'), 'show/hide side panel button');
@@ -20,6 +21,7 @@ export class SidePanel extends ui.BaseElement {
   infotipIconExperience = new ui.Clickable(this.$('.infotip-group-type-44795662-db7a-44f7-a4e7-c6d41d3eff27'));
   infotipIconRequirement = new ui.Clickable(this.$('.infotip-group-type-6d254168-6937-447f-a093-0c38404bd072'));
   infotipPopover =  new ui.BaseElementArray(this.$$('.pficon-close'));
+  workItemList = new WorkItemList($('alm-work-item-list'));
 
   constructor(ele: ElementFinder, name: string = 'WorkItem List page Side Panel') {
     super(ele, name);
@@ -38,14 +40,17 @@ export class SidePanel extends ui.BaseElement {
 
   async clickScenarios() {
     await this.scenarioButton.clickWhenReady();
+    await this.workItemList.overlay.untilHidden();
   }
 
   async clickExperience() {
     await this.experienceButton.clickWhenReady();
+    await this.workItemList.overlay.untilHidden();
   }
 
   async clickRequirement() {
     await this.requirementsButton.clickWhenReady();
+    await this.workItemList.overlay.untilHidden();
   }
 
   async createNewIteration() {

--- a/src/tests/ui/planner/toolbarHeader.ts
+++ b/src/tests/ui/planner/toolbarHeader.ts
@@ -1,6 +1,7 @@
-import { $$, browser, ElementFinder } from 'protractor';
+import { $, $$, browser, ElementFinder } from 'protractor';
 import * as ui from '../../ui';
 import { BaseElement } from './../base.element';
+import { WorkItemList } from './workitem-list';
 
 export class ToolbarHeader extends BaseElement {
   notificationToast = new ui.BaseElementArray($$('pfng-toast-notification'), 'Notification Toast');
@@ -24,6 +25,7 @@ export class ToolbarHeader extends BaseElement {
   closeBtn = new ui.Button(this.$('.cancel-cq-btn'), 'Cancel');
   titleTextInput = new ui.TextInput(this.saveFilterDialog.$('input.form-control'), 'Query Title');
   activeFiltersList = new ui.BaseElementArray(this.$$('.f8-filters--active li'), 'Active filters div');
+  workItemList = new WorkItemList($('alm-work-item-list'));
 
   constructor(el: ElementFinder, name = 'ToolBar Header') {
     super(el, name);
@@ -36,15 +38,8 @@ export class ToolbarHeader extends BaseElement {
 
   async clickShowTree() {
     await this.ready();
-    while (true) {
-      try {
-        await this.showTree.clickWhenReady();
-        break;
-      } catch (e) {
-        await browser.sleep(1000);
-        await this.notificationToast.untilCount(0);
-      }
-    }
+    await this.showTree.clickWhenReady();
+    await this.workItemList.overlay.untilHidden();
   }
 
   async selectFilter(Label: string, LabelTest: string) {
@@ -53,24 +48,19 @@ export class ToolbarHeader extends BaseElement {
     await this.filterDropdown.select(Label);
     await this.selectFilterCondition.clickWhenReady();
     await this.selectFilterCondition.select(LabelTest);
+    await this.workItemList.overlay.untilHidden();
   }
 
   async clickClearAllFilters() {
     await this.clearAllFilter.clickWhenReady();
+    await this.workItemList.overlay.untilHidden();
   }
 
   async clickShowCompleted() {
     await this.ready();
     await this.showCompleted.untilDisplayed();
-    while (true) {
-      try {
-        await this.showCompleted.clickWhenReady();
-        break;
-      } catch (e) {
-        await browser.sleep(1000);
-        await this.notificationToast.untilCount(0);
-      }
-    }
+    await this.showCompleted.clickWhenReady();
+    await this.workItemList.overlay.untilHidden();
   }
 
   async saveFilters(title: string) {

--- a/src/tests/ui/planner/workitem-quickadd.ts
+++ b/src/tests/ui/planner/workitem-quickadd.ts
@@ -50,7 +50,9 @@ export class WorkItemQuickAdd extends ui.BaseElement {
   async addAndOpenWorkItem({ title, description = '', type = '' }: WorkItem) {
     await this.workItemTypeDropdown.clickWhenReady();
     await this.workItemTypeDropdown.select(type);
+    await this.titleTextInput.ready();
     await this.titleTextInput.enterText(title);
+    await this.addAndOpenButton.untilClickable();
     await this.addAndOpenButton.clickWhenReady();
     this.log('New WorkItem created', `${title} added`);
   }

--- a/src/tests/ui/planner/workitem-quickpreview.ts
+++ b/src/tests/ui/planner/workitem-quickpreview.ts
@@ -13,7 +13,8 @@ export class WorkItemQuickPreview extends ui.BaseElement {
   stateDiv = new ui.BaseElement(this.$('#wi-preview-state'), ' State toggle');
   iterationDropdownCloseButton = new ui.Button(this.$('.iteration-dropdown .close-pointer'), 'Iteration dropdown close button');
   areaDropdownCloseButton = new ui.Button(this.$('.area-dropdown .close-pointer'), 'Area dropdown close button');
-  stateDropdown = new ui.Dropdown(this.$('.dropdown-toggle'), this.$('#wi-status-dropdown'), 'WorkItem State dropdown');
+  stateToggle = new ui.BaseElement(this.$('.dropdown-toggle'), 'State dropdown toggle');
+  stateDropdown = new ui.Dropdown(this.stateToggle, this.$('#wi-status-dropdown'), 'WorkItem State dropdown');
   fullDetailButton = new ui.Clickable(this.$('span.dib'), 'View full details button');
   titleDiv = new ui.BaseElement(this.$('#wi-title-div'), 'Workitem title div');
   titleInput = new ui.TextInput(this.titleDiv.$('textarea'), 'WorkItem Title Input');
@@ -149,7 +150,6 @@ export class WorkItemQuickPreview extends ui.BaseElement {
     await this.iterationDropdown.clickWhenReady();
     await this.iterationDropdown.select(iterationTitle);
     await this.iterationDropdownCloseButton.clickWhenReady();
-    await this.notificationToast.untilCount(1);
   }
 
   async typeaHeadSearch(iterationTitle: string) {
@@ -219,17 +219,8 @@ export class WorkItemQuickPreview extends ui.BaseElement {
     await this.loadingAnimation.untilCount(0);
   }
 
-  // Try to click on the close button, if it fails, wait for notification to disappear
   async close() {
-    while (true) {
-      try {
-        await this.closeButton.clickWhenReady();
-        break;
-      } catch (e) {
-        await browser.sleep(1000);
-        await this.notificationToast.untilCount(0);
-      }
-    }
+    await this.closeButton.clickWhenReady();
   }
 
   async getArea() {
@@ -303,6 +294,7 @@ export class WorkItemQuickPreview extends ui.BaseElement {
     }
     await this.titleInput.enterText(title);
     await this.titleSaveButton.clickWhenReady();
+    await this.titleInput.untilTextIsPresentInValue(title);
   }
 
   async updateDescription(description: string, append: boolean = false) {
@@ -341,6 +333,7 @@ export class WorkItemQuickPreview extends ui.BaseElement {
   async changeStateTo(state: string) {
     await this.stateDropdown.clickWhenReady();
     await this.stateDropdown.select(state);
+    await this.stateToggle.untilTextIsPresent(state);
   }
 
   /* Agile Template */


### PR DESCRIPTION
### Mandatory
 - [ ] What does this PR do? 
Suppresses the create and update toast notifications.
Now only error notifications will be shown

- [ ] What issue/task does this PR references?
https://github.com/openshiftio/openshift.io/issues/1554

- [ ] Are the tests Included?
___
### Optional
- [ ] Is the documentation Included?

- [ ] Are the Release Notes included?
<!-- For inclusion in marketing announcement - N/A for bugs. -->
<!-- A brief two line documentation of the functionality added/improved -->

- [ ] @mention(s) to expected reviewer(s) included
