### PR TITLE
fix(inlineQuickAdd): Order of Child-Types in WorkItemType Dropown

### DIFF
--- a/src/app/models/work-item-type.ts
+++ b/src/app/models/work-item-type.ts
@@ -4,6 +4,7 @@ import {
   MapTree,
   modelService,
   modelUI,
+  normalizeArray,
   switchModel
 } from './common.model';
 import { WorkItemService } from './work-item';
@@ -144,16 +145,16 @@ export class WorkItemTypeMapper implements Mapper<WorkItemTypeService, WorkItemT
 
 export class WorkItemTypeResolver {
   private allTypes: WorkItemTypeUI[];
+  private normalizedTypes: {[id: string]: WorkItemTypeUI};
 
   constructor(allTypes: WorkItemTypeUI[] = []) {
     this.allTypes = allTypes;
+    this.normalizedTypes = normalizeArray(allTypes);
   }
 
   resolveChildren() {
     this.allTypes.forEach(type => {
-      type.childTypes = this.allTypes.filter(t => {
-        return type.childTypes.findIndex(ct => ct.id === t.id) > -1;
-      });
+      type.childTypes = type.childTypes.map(ct => this.normalizedTypes[ct.id]);
     });
   }
 

--- a/src/tests/specs/agileTemplate.spec.ts
+++ b/src/tests/specs/agileTemplate.spec.ts
@@ -56,4 +56,46 @@ describe('Agile template tests: ', () => {
     await planner1.quickPreview.businessValue.untilTextIsPresentInValue('Business value for this Theme');
     expect(await planner1.quickPreview.businessValue.getAttribute('value')).toBe('Business value for this Theme');
   });
+
+  it('should create a workitem of type THEME and check for the order of child types in dropdown', async () => {
+    let newWorkItem = { title: 'Theme 1', type : 'Theme'};
+    await planner1.createWorkItem(newWorkItem);
+    expect(planner1.workItemList.hasWorkItem(newWorkItem.title)).toBeTruthy();
+    // open the inline quick add for newly created WorkItem
+    await planner1.workItemList.workItem(newWorkItem.title).clickInlineQuickAdd();
+    // get the workItem types for inline quick add
+    let wiTypes = await planner1.inlineQuickAdd.workItemTypes();
+    expect(wiTypes.length).toBe(3);
+    expect(wiTypes[0]).toBe('Defect');
+    expect(wiTypes[1]).toBe('Epic');
+    expect(wiTypes[2]).toBe('Impediment');
+  });
+
+  it('should create a workitem of type EPIC and check for the order of child types in dropdown', async () => {
+    let newWorkItem = { title: 'Epic 1', type : 'Epic'};
+    await planner1.createWorkItem(newWorkItem);
+    expect(planner1.workItemList.hasWorkItem(newWorkItem.title)).toBeTruthy();
+    // open the inline quick add for newly created WorkItem
+    await planner1.workItemList.workItem(newWorkItem.title).clickInlineQuickAdd();
+    // get the workItem types for inline quick add
+    let wiTypes = await planner1.inlineQuickAdd.workItemTypes();
+    expect(wiTypes.length).toBe(3);
+    expect(wiTypes[0]).toBe('Defect');
+    expect(wiTypes[1]).toBe('Story');
+    expect(wiTypes[2]).toBe('Impediment');
+  });
+
+  it('should create a workitem of type STORY and check for the order of child types in dropdown', async () => {
+    let newWorkItem = { title: 'Story 1', type : 'Story'};
+    await planner1.createWorkItem(newWorkItem);
+    expect(planner1.workItemList.hasWorkItem(newWorkItem.title)).toBeTruthy();
+    // open the inline quick add for newly created WorkItem
+    await planner1.workItemList.workItem(newWorkItem.title).clickInlineQuickAdd();
+    // get the workItem types for inline quick add
+    let wiTypes = await planner1.inlineQuickAdd.workItemTypes();
+    expect(wiTypes.length).toBe(3);
+    expect(wiTypes[0]).toBe('Task');
+    expect(wiTypes[1]).toBe('Defect');
+    expect(wiTypes[2]).toBe('Impediment');
+  });
 });


### PR DESCRIPTION
<strong>Note: If there are pending changes to the PR, prefix the PR title with "WIP" and add the label "DO NOT MERGE"</strong>

### Mandatory
 - [x] What does this PR do? 
 - Fix: The order of Work Item child-types in the inline Quick Add 

- [x] What issue/task does this PR references?
https://openshift.io/openshiftio/Openshift_io/plan/detail/41

- [x] Are the tests Included?
YES
___
### Optional
- [ ] Is the documentation Included?

- [ ] Are the Release Notes included?
<!-- For inclusion in marketing announcement - N/A for bugs. -->
<!-- A brief two line documentation of the functionality added/improved -->

- [ ] @mention(s) to expected reviewer(s) included
