### PR TITLE
Fix failing builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV NODE_VERSION 8.3.0
 RUN rpm -U http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-2.noarch.rpm
 
 RUN yum -y update && \
-    yum install -y bzip2 git epel-release libappindicator \
+    yum install -y bzip2 git epel-release libappindicator python-devel\
       java-1.8.0-openjdk wget unzip which gcc-c++ && \
       yum -y clean all
 

--- a/tests/run_e2e_tests.sh
+++ b/tests/run_e2e_tests.sh
@@ -27,6 +27,7 @@ generate_db() {
   log "Installing python pip"
   yum install -y epel-release && yum install -y python-pip
   log "Installing all the required packages..."
+  pip install --upgrade pip
   pip install pytest requests jmespath
   log "Running the EE_API_Automation Tests (DB Generation)"
   sh run_me.sh "$FABRIC8_WIT_API_URL" "$USER_NAME" "$REFRESH_TOKEN"


### PR DESCRIPTION
All builds related to planner are failing.
This PR updates the version of pip used in the containers for API tests and also install the python-devel package.