### PR TITLE
fix(test): Change spec timeout from 60 mins to 3 mins

### DIFF
--- a/tests/protractor.conf.ts
+++ b/tests/protractor.conf.ts
@@ -27,7 +27,7 @@ let conf: Config = {
     showColors: true,
     silent: true,
     isVerbose: true,
-    defaultTimeoutInterval: 60 * 60 * 1000 // 60 mins for spec to run
+    defaultTimeoutInterval: 3 * 60 * 1000 // 3 mins for spec to run
   },
 
   directConnect: process.env.DIRECT_CONNECTION === "true",


### PR DESCRIPTION
60 mins is too much for each spec. 
I have reduced the timeout from 60 mins to 3 mins