### PR TITLE
fix(query): fix provider dependencies for local env using feature-flag

### DIFF
--- a/src/app/components_ngrx/planner-query/planner-query.module.ts
+++ b/src/app/components_ngrx/planner-query/planner-query.module.ts
@@ -3,6 +3,9 @@ import { NgModule } from '@angular/core';
 import { PlannerQueryRoutingModule } from './planner-query-routing.module';
 import { PlannerQueryComponent } from './planner-query.component';
 
+import { FeatureFlagResolver, FeatureTogglesService } from 'ngx-feature-flag';
+import { togglesApiUrlProvider } from '../../shared/toggles-api.provider';
+
 @NgModule({
   imports: [
     CommonModule,
@@ -13,6 +16,9 @@ import { PlannerQueryComponent } from './planner-query.component';
   ],
   exports: [
     PlannerQueryComponent
+  ],
+  providers: [
+    FeatureFlagResolver, FeatureTogglesService, togglesApiUrlProvider
   ]
 })
 export class PlannerQueryModule { }

--- a/src/app/shared/toggles-api.provider.ts
+++ b/src/app/shared/toggles-api.provider.ts
@@ -1,0 +1,12 @@
+import { InjectionToken } from '@angular/core';
+import { FABRIC8_FEATURE_TOGGLES_API_URL } from 'ngx-feature-flag';
+
+let witApiUrlFactory = () => {
+  return process.env.FABRIC8_WIT_API_URL;
+};
+
+// for now use wit proxy for toggles-services
+export let togglesApiUrlProvider = {
+  provide: FABRIC8_FEATURE_TOGGLES_API_URL as InjectionToken<string>,
+  useFactory: witApiUrlFactory
+};


### PR DESCRIPTION
<strong>Note: If there are pending changes to the PR, prefix the PR title with "WIP" and add the label "DO NOT MERGE"</strong>

### Mandatory
 - [ ] What does this PR do? 
- Due to some npm dependency issue in `npm link` feature-flag was not working locally when linking fabric8-planner with fabric8-ui, but it was working fine for prod builds on centOS as well as local fabric8-ui with the latest planner@0.53.2. 
- So in this PR fixes this issue by providing `FeatureFlagResolver`and other FeatureFlag related dependencies explicitly. 
- It also provides `FABRIC8_FEATURE_TOGGLES_API_URL` explicitly by using `process.env.FABRIC8_WIT_API_URL` as a factory since toggle service uses `WIT_API_URL` as a proxy. 
- This patch works both locally and with prod builds.

- [ ] What issue/task does this PR references?

- [ ] Are the tests Included?
___
### Optional
- [ ] Is the documentation Included?

- [ ] Are the Release Notes included?
<!-- For inclusion in marketing announcement - N/A for bugs. -->
<!-- A brief two line documentation of the functionality added/improved -->

- [ ] @mention(s) to expected reviewer(s) included
