### PR TITLE
[WIP]fix(quick-preview): close quick preview while navigating between group-types

### DIFF
--- a/src/app/components_ngrx/dynamic-field/dynamic-field.component.html
+++ b/src/app/components_ngrx/dynamic-field/dynamic-field.component.html
@@ -16,6 +16,7 @@
         [type]="fieldValue.field.type.kind"
         [value]="fieldValue.value"
         (onSave)="saveInputField($event)"
+        (onEdit)="isDynamicFieldDirty($event)"
         [placeholder]="fieldValue.field.label">
       </f8-inlineinput>
 
@@ -28,7 +29,8 @@
         [items]="dropdownMenuItems"
         [selectedItems]="dropdownSelectedItems"
         class="dynamic-enum-dropdown"
-        (onCloseSelector)="onChangeDropdown($event)">
+        (onCloseSelector)="onChangeDropdown($event)"
+        (onOpenSelector)="isDynamicFieldDirty($event)">
       </common-selector>
 
       <!-- workitemtype field type: boolean -->
@@ -40,7 +42,8 @@
         [items]="dropdownMenuItems"
         [selectedItems]="dropdownSelectedItems"
         class="dynamic-boolean-dropdown"
-        (onCloseSelector)="onChangeDropdown($event)">
+        (onCloseSelector)="onChangeDropdown($event)"
+        (onOpenSelector)="isDynamicFieldDirty($event)">
       </common-selector>
 
 
@@ -51,7 +54,8 @@
         [rawText]="fieldValue?.value?.content"
         [renderedText]="fieldValue?.value?.rendered"
         (onSaveClick)="markupUpdate($event)"
-        (showPreview)="showPreview($event)">
+        (showPreview)="showPreview($event)"
+        (onActiveEditor)="isDynamicFieldDirty($event)">
       </f8-markdown>
 
       <!-- workitemtype field type: instant (datetime) -->

--- a/src/app/components_ngrx/dynamic-field/dynamic-field.component.ts
+++ b/src/app/components_ngrx/dynamic-field/dynamic-field.component.ts
@@ -49,6 +49,9 @@ export class DynamicFieldComponent implements OnInit {
   private markupCallBack: any = null;
   private showField: boolean = true;
 
+  // private editInlineInput: boolean = false;
+  // private commonSelectorOpen: boolean = false;
+
   // this is the input for dynamic field key and value
   @Input('keyValueField') set fieldValueSetter(val) {
     this.fieldValue = cloneDeep(val);
@@ -105,6 +108,8 @@ export class DynamicFieldComponent implements OnInit {
 
   // event when value is updated, emits new value as the event.
   @Output() readonly onUpdate = new EventEmitter();
+
+  @Output() readonly onDynamicFieldDirty = new EventEmitter();
 
   // the attribute key we're dealing with.
   attributeKey: string;
@@ -290,5 +295,11 @@ export class DynamicFieldComponent implements OnInit {
     // setting the form value to the (old) data value and mark it as pristine
     // this.form.controls[this.attributeKey].patchValue(this.oldValue);
     // this.form.controls[this.attributeKey].markAsPristine();
+  }
+
+  isDynamicFieldDirty(e) {
+    if (e == 'open' || e == true) {
+      this.onDynamicFieldDirty.emit(true);
+    }
   }
 }

--- a/src/app/components_ngrx/group-types-panel/group-types-panel.component.ts
+++ b/src/app/components_ngrx/group-types-panel/group-types-panel.component.ts
@@ -9,6 +9,8 @@ import { AuthenticationService } from 'ngx-login-client';
 
 import { GroupTypeQuery, GroupTypeUI } from '../../models/group-types.model';
 import { FilterService } from '../../services/filter.service';
+import { GroupTypesService } from '../../services/group-types.service';
+import { ModalService } from '../../services/modal.service';
 
 // ngrx stuff
 import { Store } from '@ngrx/store';
@@ -47,7 +49,8 @@ export class GroupTypesComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private router: Router,
     private spaces: Spaces,
-    private store: Store<AppState>
+    private store: Store<AppState>,
+    private modalService: ModalService
   ) {}
 
   ngOnInit(): void {
@@ -178,9 +181,26 @@ export class GroupTypesComponent implements OnInit, OnDestroy {
 
   //This function navigates to the desired work item group type page
   groupTypeClickHandler(e: MouseEvent, item: GroupTypeUI) {
-    if (this.isQuickPreviewOpen = true) {
-      this.quickPreview.quickPreview.closeDetail();
+    if (this.isQuickPreviewOpen) {
+      if (this.quickPreview.quickPreview.isQuickPreviewDirty == 'open' ||
+       this.quickPreview.quickPreview.isQuickPreviewDirty == true) {
+        this.modalService.openModal('Modify Work Item', 'You have made some changes to this workitem.'
+        + ' Would you like to save the changes?', 'Save', 'Cancel', 'saveWorkItem', 'cancel')
+        .first()
+        .subscribe(actionKey => {
+          if (actionKey !== 'saveWorkItem') {
+            this.groupTypeNavigation(e, item);
+          }
+        });
+      } else {
+        this.groupTypeNavigation(e, item);
+      }
+    } else {
+      this.groupTypeNavigation(e, item);
     }
+  }
+  groupTypeNavigation(e: MouseEvent, item: GroupTypeUI) {
+    this.quickPreview.quickPreview.closeDetail();
     if (!e.srcElement.classList.contains('infotip-icon')) {
       let q = this.addRemoveQueryParams(item);
       this.router.navigate([], {

--- a/src/app/components_ngrx/group-types-panel/group-types-panel.component.ts
+++ b/src/app/components_ngrx/group-types-panel/group-types-panel.component.ts
@@ -15,6 +15,7 @@ import { Store } from '@ngrx/store';
 import { SpaceQuery } from '../../models/space';
 import * as GroupTypeActions from './../../actions/group-type.actions';
 import { AppState } from './../../states/app.state';
+import { WorkItemPreviewPanelComponent } from './../work-item-preview-panel/work-item-preview-panel.component';
 
 @Component({
   selector: 'group-types',
@@ -25,6 +26,8 @@ export class GroupTypesComponent implements OnInit, OnDestroy {
 
   @Input() sidePanelOpen: boolean = true;
   @Input() context: 'list' | 'board'; // 'list' or 'board'
+  @Input() quickPreview: WorkItemPreviewPanelComponent;
+  @Input() isQuickPreviewOpen: boolean;
 
   authUser: any = null;
   infotipSource = this.store
@@ -175,6 +178,9 @@ export class GroupTypesComponent implements OnInit, OnDestroy {
 
   //This function navigates to the desired work item group type page
   groupTypeClickHandler(e: MouseEvent, item: GroupTypeUI) {
+    if (this.isQuickPreviewOpen = true) {
+      this.quickPreview.quickPreview.closeDetail();
+    }
     if (!e.srcElement.classList.contains('infotip-icon')) {
       let q = this.addRemoveQueryParams(item);
       this.router.navigate([], {

--- a/src/app/components_ngrx/planner-list/planner-list.component.html
+++ b/src/app/components_ngrx/planner-list/planner-list.component.html
@@ -14,7 +14,10 @@
       [sidePanelContent]="sidePanel"
       [sectionContent]="sectionPanel">
     </alm-planner-layout>
-    <work-item-preview-panel #quickPreview >
+    <work-item-preview-panel
+      (onOpen)="isQuickPreviewOpen = true"
+      (onClose)="isQuickPreviewOpen = false"
+      #quickPreview >
     </work-item-preview-panel>
   </main>
 </div>
@@ -39,7 +42,9 @@
       </span>
     </a>
     <side-panel
-      [sidePanelOpen]="sidePanelOpen">
+      [sidePanelOpen]="sidePanelOpen"
+      [isQuickPreviewOpen]="isQuickPreviewOpen"
+      [quickPreview]="quickPreview">
     </side-panel>
   </aside>
 </ng-template>

--- a/src/app/components_ngrx/planner-list/planner-list.component.ts
+++ b/src/app/components_ngrx/planner-list/planner-list.component.ts
@@ -89,6 +89,7 @@ export class PlannerListComponent implements OnInit, OnDestroy, AfterViewChecked
   private toolbarHt: number = 0;
   private quickaddHt: number = 0;
   private showCompleted: boolean = false;
+  private isQuickPreviewOpen: boolean = false;
 
   @ViewChild('plannerLayout') plannerLayout: PlannerLayoutComponent;
   @ViewChild('toolbar') toolbar: ElementRef;

--- a/src/app/components_ngrx/side-panel/side-panel.component.html
+++ b/src/app/components_ngrx/side-panel/side-panel.component.html
@@ -1,6 +1,8 @@
 <group-types
   [sidePanelOpen]="sidePanelOpen"
-  [context]="context">
+  [context]="context"
+  [isQuickPreviewOpen]="isQuickPreviewOpen"
+  [quickPreview]="quickPreview">
 </group-types>
 <custom-query
   [sidePanelOpen]="sidePanelOpen"

--- a/src/app/components_ngrx/side-panel/side-panel.component.ts
+++ b/src/app/components_ngrx/side-panel/side-panel.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { WorkItemPreviewPanelComponent } from '../work-item-preview-panel/work-item-preview-panel.component';
 
 @Component({
   selector: 'side-panel',
@@ -9,6 +10,8 @@ export class SidepanelComponent implements OnInit {
 
   @Input() sidePanelOpen: boolean = true;
   @Input() context: 'list' | 'board' = 'list'; // 'list' or 'board'
+  @Input() quickPreview: WorkItemPreviewPanelComponent;
+  @Input() isQuickPreviewOpen: boolean;
 
   backlogSelected: boolean = true;
   typeGroupSelected: boolean = true;

--- a/src/app/components_ngrx/work-item-detail/work-item-detail.component.html
+++ b/src/app/components_ngrx/work-item-detail/work-item-detail.component.html
@@ -50,7 +50,8 @@
               [value]="workItem.title"
               (onSave)="saveTitle($event)"
               [placeholder]="'Enter title'"
-              (clickOut)="inlineInput.closeClick()">
+              (clickOut)="inlineInput.closeClick()"
+              (onEdit)="isQuickPreviewDirty = $event">
             </f8-inlineinput>
           </div>
         </div>
@@ -137,7 +138,8 @@
                       [selectedAssignees]="workItem?.assigneesObs | async"
                       [editAllow]="workItem?.editable"
                       [loggedInUser]="loggedInUser"
-                      (onOpenSelector)="onAssigneeSelectorOpen($event)"
+                      (onOpenAssignee)="onAssigneeSelectorOpen($event); 
+                        isQuickPreviewDirty = $event"
                       (onCloseAssignee)="assignUser($event)">
                     </assignee-selector>
                 </div>
@@ -164,7 +166,8 @@
                   [selectedItems]="selectedAreas | async"
                   [itemTruncate]="-25"
                   [toggleTruncate]="1000"
-                  (onCloseSelector)="areaUpdated($event)">
+                  (onCloseSelector)="areaUpdated($event)"
+                  (onOpenSelector)="isQuickPreviewDirty = $event">
                 </common-selector>
               </div>
             </section>
@@ -190,7 +193,8 @@
                   [selectedItems]="selectedIterations | async"
                   [itemTruncate]="-25"
                   [toggleTruncate]="1000"
-                  (onCloseSelector)="iterationUpdated($event)">
+                  (onCloseSelector)="iterationUpdated($event)"
+                  (onOpenSelector)="isQuickPreviewDirty = $event">
                 </common-selector>
               </div>
             </section>
@@ -218,7 +222,8 @@
                     [allLabels]="labels"
                     [selectedLabels]="workItem?.labelsObs | async"
                     [allowUpdate]="workItem?.editable"
-                    (onCloseSelector)="updateLabels($event)">
+                    (onCloseSelector)="updateLabels($event)"
+                    (onOpenSelector)="isQuickPreviewDirty = $event">
                   </label-selector>
                 </div>
               </div>
@@ -238,7 +243,8 @@
                   [rawText]="workItem.descriptionRendered!==null ? workItem.description : workItem.description.content"
                   [renderedText]="(workItem.descriptionRendered!==null ? workItem.descriptionRendered : workItem.description.rendered) | safe: 'html'"
                   (onSaveClick)="descUpdate($event)"
-                  (showPreview)="showPreview($event)" #descMarkdown>
+                  (showPreview)="showPreview($event)" 
+                  (onActiveEditor)="isQuickPreviewDirty = $event" #descMarkdown>
                 </f8-markdown>
               </div>
             </section>
@@ -252,7 +258,8 @@
                 class="db"
                 [keyValueField]="field"
                 [editAllow]="workItem?.editable"
-                (onUpdate)="dynamicFieldUpdated($event)">
+                (onUpdate)="dynamicFieldUpdated($event)"
+                (onDynamicFieldDirty)="isQuickPreviewDirty = $event">
               </alm-dynamic-field>
             </div>
             <!-- Extra fields End -->

--- a/src/app/components_ngrx/work-item-detail/work-item-detail.component.ts
+++ b/src/app/components_ngrx/work-item-detail/work-item-detail.component.ts
@@ -103,6 +103,8 @@ export class WorkItemDetailComponent implements OnInit, OnDestroy, AfterViewChec
   private dynamicFormDataArray: any;
   private dynamicKeyValueFields: {key: string; value: string | number | null; field: any}[];
 
+  isQuickPreviewDirty: string | boolean = false;
+
   constructor(
     private store: Store<AppState>,
     private route: ActivatedRoute,

--- a/src/app/components_ngrx/work-item-preview-panel/work-item-preview-panel.component.html
+++ b/src/app/components_ngrx/work-item-preview-panel/work-item-preview-panel.component.html
@@ -2,5 +2,5 @@
   <work-item-detail
     [workItem]="workItem"
     [context]="context"
-    (closePreview)="close()"></work-item-detail>
+    (closePreview)="close()" #quickPreview></work-item-detail>
 </div>

--- a/src/app/components_ngrx/work-item-preview-panel/work-item-preview-panel.component.ts
+++ b/src/app/components_ngrx/work-item-preview-panel/work-item-preview-panel.component.ts
@@ -11,9 +11,12 @@ import {
   HostListener,
   Input,
   OnInit,
-  Output
+  Output,
+  ViewChild
 } from '@angular/core';
 import { WorkItemUI } from './../../models/work-item';
+
+import { WorkItemDetailComponent } from '../work-item-detail/work-item-detail.component';
 
 @Component({
   selector: 'work-item-preview-panel',
@@ -41,6 +44,8 @@ export class WorkItemPreviewPanelComponent implements OnInit {
 
   @Output('onOpen') readonly onOpen: EventEmitter<any> = new EventEmitter();
   @Output('onClose') readonly onClose: EventEmitter<any> = new EventEmitter();
+
+  @ViewChild('quickPreview') quickPreview: WorkItemDetailComponent;
 
   private panelState: 'in' | 'out' = 'out';
   private workItem: WorkItemUI = null;

--- a/src/app/services/modal.service.ts
+++ b/src/app/services/modal.service.ts
@@ -13,9 +13,9 @@ export class ModalService {
 
   constructor() {}
 
-  public openModal(title: string, message: string, buttonText: string, actionKey?: string): Observable<string> {
-    this.componentSource.next([ title, message, buttonText, actionKey ]);
-    console.log('Opened modal dialog for key ' + actionKey);
+  public openModal(title: string, message: string, buttonText1: string, buttonText2?: string, actionKey1?: string, actionKey2?: string): Observable<string> {
+    this.componentSource.next([ title, message, buttonText1, buttonText2, actionKey1, actionKey2 ]);
+    console.log('Opened modal dialog for keys ' + actionKey1 + 'and' + actionKey2);
     return this.clientSource$;
   }
 

--- a/src/app/widgets/inlineinput/inlineinput.component.ts
+++ b/src/app/widgets/inlineinput/inlineinput.component.ts
@@ -32,6 +32,7 @@ export class InlineInputComponent implements OnInit {
   @Input() allowOnLineClickEdit: boolean = true;
 
   @Output() readonly onSave = new EventEmitter();
+  @Output() readonly onEdit = new EventEmitter();
 
   private inputValue: string = '';
   private saving: boolean = false;
@@ -55,6 +56,7 @@ export class InlineInputComponent implements OnInit {
         this.previousValue = this.inputField.nativeElement.value;
         // Set editing value as true
         this.editing = true;
+        this.onEdit.emit(this.editing);
       }
       this.inputField.nativeElement.focus();
     } else {

--- a/src/app/widgets/modal/modal.component.html
+++ b/src/app/widgets/modal/modal.component.html
@@ -7,16 +7,16 @@
       </div>
       <!-- Action buttons to cancel/delete -->
       <div class="text-right">
-        <button class="btn"
+        <button *ngIf="buttonText2" class="btn"
           id="modal-cancel"
           type="submit"
-          (click)="modal.close()">
-            Cancel
+          (click)="doAction(actionKey2); modal.close()">
+            {{ buttonText2 }}
         </button>
         <button class="btn btn-danger"
           id="modal-confirm"
-          (click)="doAction(); modal.close()">
-            {{ buttonText }}
+          (click)="doAction(actionKey1); modal.close()">
+            {{ buttonText1 }}
         </button>
       </div>
     </div>

--- a/src/app/widgets/modal/modal.component.ts
+++ b/src/app/widgets/modal/modal.component.ts
@@ -16,16 +16,19 @@ export class ModalComponent implements OnDestroy {
 
   @ViewChild('OSIOModal') private modal: Modal;
   private title: string;
-  private buttonText: string;
+  private buttonText1: string;
+  private buttonText2: string;
   private message: string;
-  private actionKey: string;
+  private actionKey1: string;
+  private actionKey2: string;
   eventListeners: any[] = [];
 
   constructor(private modalService: ModalService) {
     this.eventListeners.push(
       this.modalService.getComponentObservable().subscribe((params: string[]) => {
-        this.actionKey = params[3];
-        this.open(params[0], params[1], params[2]);
+        this.actionKey1 = params[4];
+        this.actionKey2 = params[5];
+        this.open(params[0], params[1], params[2], params[3]);
       })
     );
   }
@@ -34,14 +37,15 @@ export class ModalComponent implements OnDestroy {
     this.eventListeners.forEach(e => e.unsubscribe());
   }
 
-  public open(title: string, message: string, buttonText: string) {
+  public open(title: string, message: string, buttonText1: string, buttonText2?: string) {
     this.title = title;
     this.message = message;
-    this.buttonText = buttonText;
+    this.buttonText1 = buttonText1;
+    this.buttonText2 = buttonText2;
     this.modal.open();
   }
 
-  public doAction() {
-    this.modalService.doAction(this.actionKey);
+  public doAction(actionKey) {
+    this.modalService.doAction(actionKey);
   }
 }

--- a/src/tests/specs/smoke/smokeTest.spec.ts
+++ b/src/tests/specs/smoke/smokeTest.spec.ts
@@ -69,6 +69,7 @@ describe('Planner Smoke Tests:', () => {
     await planner.workItemList.clickWorkItem(title);
     await planner.quickPreview.updateTitle('');
     expect(await planner.quickPreview.getTitleError()).toBe('Empty title not allowed');
+    await planner.quickPreview.titleCancelButton.clickWhenReady();
   });
 
   //creator is no more a field in the quick-preview/detail-page as per the new design


### PR DESCRIPTION
<strong>Note: If there are pending changes to the PR, prefix the PR title with "WIP" and add the label "DO NOT MERGE"</strong>

### Mandatory
 - [ ] What does this PR do? 
- This PR implements closing of quick-preview, if open, if user switches between or clicks on any group-type.
- If there are any unsaved workitem changes in the quick-preview it will ask the user to save the changes if they want to.
- Blockers:
  
  - Currently we have close on outside-click on most of the fields in quick-preview so when any of these fields have unsaved changes and then save button is clicked on the modal the fields gets closed because of outside-click functionality. 
- [ ] What issue/task does this PR references?
       Fixes https://github.com/openshiftio/openshift.io/issues/2598

- [ ] Are the tests Included?
       WIP
### Optional
- [ ] Is the documentation Included?

- [ ] Are the Release Notes included?
<!-- For inclusion in marketing announcement - N/A for bugs. -->
<!-- A brief two line documentation of the functionality added/improved -->

- [ ] @mention(s) to expected reviewer(s) included
