### PR TITLE
fix(builds): Add unsafe-perm flag to npm install 

### DIFF
--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -59,7 +59,7 @@ function run_functional_tests() {
 function build_fabric8_ui() {
     # Build and integrate planner with fabric8-ui
     docker exec $CID git clone https://github.com/fabric8-ui/fabric8-ui.git
-    docker exec $CID bash -c 'cd fabric8-ui; npm install'
+    docker exec $CID bash -c 'cd fabric8-ui; npm install --unsafe-perm'
     docker exec $CID bash -c 'cd fabric8-ui && npm install ../*0.0.0-development.tgz'
     docker exec $CID bash -c '''
         export FABRIC8_WIT_API_URL="https://api.prod-preview.openshift.io/api/"
@@ -67,11 +67,11 @@ function build_fabric8_ui() {
         export FABRIC8_FORGE_API_URL="https://forge.api.prod-preview.openshift.io"
         export FABRIC8_SSO_API_URL="https://sso.prod-preview.openshift.io/"
         export FABRIC8_AUTH_API_URL="https://auth.prod-preview.openshift.io/api/"
-        
+
         export OPENSHIFT_CONSOLE_URL="https://console.free-stg.openshift.com/console/"
         export WS_K8S_API_SERVER="f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443"
         export FABRIC8_FEATURE_TOGGLES_API_URL="f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com:443" 
-        
+
         export PROXIED_K8S_API_SERVER="${WS_K8S_API_SERVER}"
         export OAUTH_ISSUER="https://${WS_K8S_API_SERVER}"
         export PROXY_PASS_URL="https://${WS_K8S_API_SERVER}"

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -59,6 +59,10 @@ function run_functional_tests() {
 function build_fabric8_ui() {
     # Build and integrate planner with fabric8-ui
     docker exec $CID git clone https://github.com/fabric8-ui/fabric8-ui.git
+    # Do not remove the --unsafe-perm flag.
+    # fabric8-ui contains `postinstall.sh` script and the since it will be
+    # executed in a docker container with root privileges we need the
+    # --unsafe-perm flag.
     docker exec $CID bash -c 'cd fabric8-ui; npm install --unsafe-perm'
     docker exec $CID bash -c 'cd fabric8-ui && npm install ../*0.0.0-development.tgz'
     docker exec $CID bash -c '''

--- a/src/app/reducers/iteration-reducer.ts
+++ b/src/app/reducers/iteration-reducer.ts
@@ -40,7 +40,10 @@ export const iterationReducer: ActionReducer<IterationState> =
             state[id].showChildren = false;
           }
           let pId = state[action.payload].parentId;
-          while (pId) {
+          // Backend sends the pId for root iteration '00000000-0000-0000-0000-000000000000'
+          // removing pId !== '00000000-0000-0000-0000-000000000000' causes the while loop to go in
+          // infinite loop
+          while (pId && pId !== '00000000-0000-0000-0000-000000000000') {
             const pIndex = pId;
             if (state[pId]) {
               state[pId].showChildren = true;

--- a/src/app/services/work-item.service.ts
+++ b/src/app/services/work-item.service.ts
@@ -84,17 +84,21 @@ export class WorkItemService {
     return this.httpClientService
       .get<{
         data: WorkItem[],
-        links: {next: string},
+        links: {
+          first?: string,
+          last?: string,
+          next?: string
+        },
         meta: {
           totalCount: number,
           ancestorIDs: string[]},
         included: WorkItem[]}
-        >(url)
+      >(url)
       .pipe(
         map((resp) => {
           return {
             workItems: resp.data as WorkItem[],
-            nextLink: resp.links.next,
+            nextLink: resp.links.next ? resp.links.next : '',
             totalCount: resp.meta ? resp.meta.totalCount : 0,
             included: resp.included ? resp.included as WorkItem[] : [],
             ancestorIDs: resp.meta.ancestorIDs ? resp.meta.ancestorIDs : []

--- a/src/app/services/work-item.snapshot.ts
+++ b/src/app/services/work-item.snapshot.ts
@@ -1116,7 +1116,7 @@ export const workItemSnapshot = {
 
 export const getWorkItemResponseSnapshot = {
     workItems: workItemSnapshot.data,
-    nextLink: undefined,
+    nextLink: '',
     totalCount: workItemSnapshot.meta.totalCount,
     included: workItemSnapshot.included,
     ancestorIDs: workItemSnapshot.meta.ancestorIDs


### PR DESCRIPTION
fabric8-ui contains a postinstall.sh script which will not work inside a container that is running with super user privileges. The postinstall script in fabric8-ui fails with
```
npm WARN lifecycle fabric8-ui@0.0.0-development~postinstall: cannot run in wd %s %s (wd=%s) fabric8-ui@0.0.0-development ./post-install.sh /home/fabric8/fabric8-planner/fabric8-ui
``` 
on cico (docker container).  

Example failure: https://ci.centos.org/view/Devtools/job/devtools-fabric8-planner-f8planner/2065/consoleFull

https://github.com/fabric8-ui/fabric8-ui/pull/3283/ updated fabric8-ui and caused all builds on fabric8-planner to fail.

More information on https://stackoverflow.com/questions/18136746/npm-install-failed-with-cannot-run-in-wd

Also Fixes the Sev-1: https://github.com/openshiftio/openshift.io/issues/4309