### PR TITLE
fix(dynamic-component): Remove None from Enum field values

### DIFF
--- a/src/app/components_ngrx/dynamic-field/dynamic-field.component.html
+++ b/src/app/components_ngrx/dynamic-field/dynamic-field.component.html
@@ -22,7 +22,6 @@
       <!-- workitemtype field type: dropdown -->
       <common-selector
         *ngIf="fieldValue.field.type.kind==='enum'"
-        [noValueLabel]="'None'"
         [allowUpdate]="editAllow"
         [headerText]="fieldValue.field.label + ' dropdown'"
         [items]="dropdownMenuItems"

--- a/src/app/components_ngrx/dynamic-field/dynamic-field.component.ts
+++ b/src/app/components_ngrx/dynamic-field/dynamic-field.component.ts
@@ -167,7 +167,6 @@ export class DynamicFieldComponent implements OnInit {
 
   extractEnumKeyValues(possibleOptions: string[]): any[] {
     return [
-      {key: null, value: 'None'},
       ...possibleOptions.map(v => {
         return {
           key: v,


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/3831 and https://github.com/openshiftio/openshift.io/issues/3832#issuecomment-433874194

This PR removes the unnecessary `None` field in the dropdown for enum types. The backend would always send a default value for enum fields.

**Before**
>![](https://user-images.githubusercontent.com/193408/47646579-a1150a00-db74-11e8-8a70-d11de0455014.png)

**Now**
>    ![screenshot from 2018-11-01 17-26-20](https://user-images.githubusercontent.com/12949454/47850477-5a851100-ddfb-11e8-8f82-46d3b47003e5.png)
